### PR TITLE
Fix sign error on 1inch

### DIFF
--- a/src/modules/ethereum/transactions/prepareTransaction.ts
+++ b/src/modules/ethereum/transactions/prepareTransaction.ts
@@ -34,5 +34,11 @@ export function prepareTransaction(incomingTransaction: IncomingTransaction) {
   ) {
     transaction.chainId = parseInt(incomingTransaction.chainId);
   }
+  if (
+    incomingTransaction.type != null &&
+    typeof incomingTransaction.type === 'string'
+  ) {
+    transaction.type = parseInt(incomingTransaction.type);
+  }
   return transaction;
 }

--- a/src/modules/ethereum/types/IncomingTransaction.ts
+++ b/src/modules/ethereum/types/IncomingTransaction.ts
@@ -1,7 +1,11 @@
 import type { BigNumberish } from 'ethers';
 import type { UnsignedTransaction } from './UnsignedTransaction';
 
-export type IncomingTransaction = Omit<UnsignedTransaction, 'chainId'> & {
+export type IncomingTransaction = Omit<
+  UnsignedTransaction,
+  'chainId' | 'type'
+> & {
   chainId?: number | string;
   gas?: BigNumberish;
+  type?: string | number | null;
 };


### PR DESCRIPTION
When transaction has { type: "0x2" }, ethers throws a serialization error
To fix this, type must be converted to number