### PR TITLE
Remove attempt number from slack notifications

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -76,10 +76,6 @@ jobs:
                     {
                       "type": "mrkdwn",
                       "text": "*Initiated by:* ${{ github.triggering_actor }}"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Attempt:* ${{ github.run_attempt }}"
                     }
                   ]
                 }
@@ -112,10 +108,6 @@ jobs:
                     {
                       "type": "mrkdwn",
                       "text": "*Initiated by: ${{ github.triggering_actor }}"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Attempt:* ${{ github.run_attempt }}"
                     }
                   ]
                 }


### PR DESCRIPTION
Since it useless anyways and just clutters the channel