### PR TITLE
Preserve initial DOM state

### DIFF
--- a/src/content-script/in-page.ts
+++ b/src/content-script/in-page.ts
@@ -20,6 +20,7 @@ if (!scriptWithId) {
 }
 
 const walletChannelId = scriptWithId.dataset.walletChannelId;
+scriptWithId.remove(); // Remove script to preserve initial DOM shape
 if (!walletChannelId) {
   throw new Error(
     'walletChannelId must be defined as a data attribute on the script tag'


### PR DESCRIPTION
Remove mounted script tag after using it
This is necessary e.g. for SSR frameworks with hydration mechanisms to work correctly.