### PR TITLE
Fix focus ring visiblity

### DIFF
--- a/src/ui/pages/History/ActionItem/ActionItem.tsx
+++ b/src/ui/pages/History/ActionItem/ActionItem.tsx
@@ -220,6 +220,7 @@ function ActionItemBackend({
                 overflow: 'hidden',
                 textOverflow: 'ellipsis',
                 whiteSpace: 'nowrap',
+                outlineOffset: -1, // make focus ring visible despite overflow: hidden
               }}
             >
               {maybeApprovedAsset.name || maybeApprovedAsset.symbol}

--- a/src/ui/pages/History/ActionItem/TransactionItemValue.tsx
+++ b/src/ui/pages/History/ActionItem/TransactionItemValue.tsx
@@ -63,6 +63,7 @@ function HistoryTokenValue({
           overflow: 'hidden',
           textOverflow: 'ellipsis',
           whiteSpace: 'nowrap',
+          outlineOffset: -1, // make focus ring visible despite overflow: hidden
         }}
       >
         {tokenTitle}
@@ -106,6 +107,7 @@ export function HistoryNFTValue({
             overflow: 'hidden',
             textOverflow: 'ellipsis',
             whiteSpace: 'nowrap',
+            outlineOffset: -1, // make focus ring visible despite overflow: hidden
           }}
         >
           {name}


### PR DESCRIPTION
Make focus ring visible for anchors with text-overflow: ellipsis styles