### PR TITLE
Change layout styles to allow body to grow [WLT-4413]

### DIFF
--- a/src/ui/components/PageStickyFooter/PageStickyFooter.tsx
+++ b/src/ui/components/PageStickyFooter/PageStickyFooter.tsx
@@ -5,7 +5,13 @@ import { PageFullBleedLine } from '../PageFullBleedLine';
 import { UIContext } from '../UIContext';
 
 function canBeScrolled(node: HTMLElement) {
-  return node.scrollHeight > node.clientHeight;
+  if (node.scrollHeight > node.clientHeight) {
+    return true;
+  }
+  if (node.parentElement === document.documentElement) {
+    return node.clientHeight > window.innerHeight;
+  }
+  return false;
 }
 
 export function PageStickyFooter({

--- a/src/ui/style/global.module.css
+++ b/src/ui/style/global.module.css
@@ -30,6 +30,13 @@ body {
   line-height: calc(20 / 14);
   color: var(--black);
   background-color: var(--background);
+  /**
+   * Setting display: grid allows children to use {height: 100%}
+   * even when we use {min-height} for body size. This is crucial for
+   * tab and dialog views
+   * See more: https://stackoverflow.com/q/78246951/3523645
+   */
+  display: grid;
   --body-width: 425px;
   --body-height: 600px;
   width: var(--body-width);
@@ -38,7 +45,8 @@ body {
 }
 
 body.isDialog {
-  height: 100vh;
+  height: auto;
+  min-height: 100vh;
   width: 100%;
   margin: auto;
 }
@@ -48,8 +56,10 @@ body.isDialog {
 }
 
 body.isTab {
-  --body-height: 100vh;
+  --body-height: auto;
   --body-width: 450px;
+  height: auto;
+  min-height: 100vh;
   border-inline: 1px solid var(--neutral-300);
   margin-inline: auto;
 }
@@ -57,6 +67,7 @@ body.isTab {
 :global(body.isIframe) {
   --body-height: auto;
   --body-width: auto;
+  display: block; /* display: grid for some reason creates unwanted x an y overscolls */
 }
 
 :root:has(body.fullScreen) {


### PR DESCRIPTION
### Cases
* [x] All: Should grow body to at least 100% viewport height when content is smaller
* [x] Popup: should not overscroll for empty wallets (no content in overview tabs)
* [ ] ~All: when scrolling, should allow space for BugReportButton~
    We no longer have this case, could not test
* [x] Tab: should grow body when content is larger than viewport height
* [x] Tab and Dialog: PageStickyFooter should not create overscroll
* [x] Popup: should statically have fixed height so that it's consistent when it opens
* [x] Other: should _not_ have a fixed height
* [x] Canvas element for confetti effect should ideally take height of body
* [x] Should work in iframe (HW connection)
    We set back to `display: block` for this case

Others?...