### PR TITLE
Use hex gas value for interpret endpoint

### DIFF
--- a/src/modules/ethereum/transactions/interpret.ts
+++ b/src/modules/ethereum/transactions/interpret.ts
@@ -34,7 +34,7 @@ export function interpretTransaction(
               to: transaction?.to,
               nonce: transaction?.nonce,
               chainId: transaction.chainId,
-              gas: gas !== undefined ? ethers.utils.hexValue(gas) : null,
+              gas: gas != null ? ethers.utils.hexValue(gas) : null,
               gasPrice: transaction?.gasPrice,
               maxFee: transaction?.maxFeePerGas,
               maxPriorityFee: transaction?.maxPriorityFeePerGas,


### PR DESCRIPTION
The `/interpret` endpoint requires gas to be hex value