### PR TITLE
Allow longer network symbol names

### DIFF
--- a/src/ui/pages/Networks/NetworkForm/NetworkForm.tsx
+++ b/src/ui/pages/Networks/NetworkForm/NetworkForm.tsx
@@ -287,11 +287,7 @@ export function NetworkForm({
             label="Currency Symbol"
             name="nativeCurrency.symbol"
             defaultValue={chainConfig.nativeCurrency.symbol || ''}
-            pattern=".{2,}"
             error={errors['nativeCurrency.symbol']}
-            onInvalid={(event) =>
-              event.currentTarget.setCustomValidity('At least 2 letters')
-            }
             onInput={(event) => event.currentTarget.setCustomValidity('')}
             disabled={disabledFields?.has('nativeCurrency.symbol')}
             required

--- a/src/ui/pages/Networks/NetworkForm/NetworkForm.tsx
+++ b/src/ui/pages/Networks/NetworkForm/NetworkForm.tsx
@@ -287,12 +287,10 @@ export function NetworkForm({
             label="Currency Symbol"
             name="nativeCurrency.symbol"
             defaultValue={chainConfig.nativeCurrency.symbol || ''}
-            pattern=".{2,8}"
+            pattern=".{2,}"
             error={errors['nativeCurrency.symbol']}
             onInvalid={(event) =>
-              event.currentTarget.setCustomValidity(
-                'At least 2 letters, maximum 8 letters'
-              )
+              event.currentTarget.setCustomValidity('At least 2 letters')
             }
             onInput={(event) => event.currentTarget.setCustomValidity('')}
             disabled={disabledFields?.has('nativeCurrency.symbol')}


### PR DESCRIPTION
Also successful case dialog looks good after this change
<img width="425" alt="image" src="https://github.com/zeriontech/zerion-wallet-extension/assets/988849/c1bc2acf-7aa5-425d-bc84-80c8f0bc6a14">
<img width="424" alt="image" src="https://github.com/zeriontech/zerion-wallet-extension/assets/988849/993ecf50-243a-448a-8641-696fcdc5b249">
<img width="424" alt="image" src="https://github.com/zeriontech/zerion-wallet-extension/assets/988849/b94d90f4-b46d-4b79-89dd-4bb9175813c9">
