### PR TITLE
Remove chain from permissions when deleting network

### DIFF
--- a/src/background/Wallet/Wallet.ts
+++ b/src/background/Wallet/Wallet.ts
@@ -1204,13 +1204,15 @@ export class Wallet {
   }: WalletMethodParams<{ chain: string }>) {
     this.ensureRecord(this.record);
 
-    this.record = Model.removeChainFromPermissions(this.record, {
-      chain: createChain(chainStr),
+    const chain = createChain(chainStr);
+    const affectedPermissions = Model.getPermissionsByChain(this.record, {
+      chain,
     });
     affectedPermissions.forEach(({ origin }) => {
-      // TODO: remove chain for origin in case new chain is not set
       this.setChainForOrigin(createChain(NetworkId.Ethereum), origin);
     });
+    this.record = Model.removeChainFromPermissions(this.record, { chain });
+
     this.verifyOverviewChain();
     this.resetEthereumChain({ context, params: { chain: chainStr } });
   }

--- a/src/background/Wallet/Wallet.ts
+++ b/src/background/Wallet/Wallet.ts
@@ -1205,13 +1205,16 @@ export class Wallet {
     this.ensureRecord(this.record);
 
     const chain = createChain(chainStr);
+    this.record = Model.removeChainWithoutAddressesFromPermissions(
+      this.record,
+      { chain }
+    );
     const affectedPermissions = Model.getPermissionsByChain(this.record, {
       chain,
     });
     affectedPermissions.forEach(({ origin }) => {
       this.setChainForOrigin(createChain(NetworkId.Ethereum), origin);
     });
-    this.record = Model.removeChainFromPermissions(this.record, { chain });
 
     this.verifyOverviewChain();
     this.resetEthereumChain({ context, params: { chain: chainStr } });

--- a/src/background/Wallet/Wallet.ts
+++ b/src/background/Wallet/Wallet.ts
@@ -1203,13 +1203,15 @@ export class Wallet {
     params: { chain: chainStr },
   }: WalletMethodParams<{ chain: string }>) {
     this.ensureRecord(this.record);
-    const affectedPermissions = Model.getPermissionsByChain(this.record, {
+
+    this.record = Model.removeChainFromPermissions(this.record, {
       chain: createChain(chainStr),
     });
     affectedPermissions.forEach(({ origin }) => {
       // TODO: remove chain for origin in case new chain is not set
       this.setChainForOrigin(createChain(NetworkId.Ethereum), origin);
     });
+    this.verifyOverviewChain();
     this.resetEthereumChain({ context, params: { chain: chainStr } });
   }
 

--- a/src/background/Wallet/WalletRecord.ts
+++ b/src/background/Wallet/WalletRecord.ts
@@ -727,13 +727,16 @@ export class WalletRecordModel {
       .map(([origin, permission]) => ({ origin, permission }));
   }
 
-  static removeChainFromPermissions(
+  static removeChainWithoutAddressesFromPermissions(
     record: WalletRecord,
     { chain }: { chain: Chain }
   ) {
     return produce(record, (draft) => {
       for (const permission of Object.values(draft.permissions)) {
-        if (permission.chain === chain.toString()) {
+        if (
+          permission.addresses.length === 0 &&
+          permission.chain === chain.toString()
+        ) {
           delete permission.chain;
         }
       }

--- a/src/background/Wallet/WalletRecord.ts
+++ b/src/background/Wallet/WalletRecord.ts
@@ -727,6 +727,19 @@ export class WalletRecordModel {
       .map(([origin, permission]) => ({ origin, permission }));
   }
 
+  static removeChainFromPermissions(
+    record: WalletRecord,
+    { chain }: { chain: Chain }
+  ) {
+    return produce(record, (draft) => {
+      draft.permissions = Object.fromEntries(
+        Object.entries(record.permissions)
+          .filter(([, permission]) => permission.chain === chain.toString())
+          .map(([origin, { addresses }]) => [origin, { addresses }])
+      );
+    });
+  }
+
   static removeAllOriginPermissions(record: WalletRecord): WalletRecord {
     return produce(record, (draft) => {
       draft.permissions = {};

--- a/src/background/Wallet/WalletRecord.ts
+++ b/src/background/Wallet/WalletRecord.ts
@@ -724,15 +724,13 @@ export class WalletRecordModel {
   ) {
     return produce(record, (draft) => {
       draft.permissions = Object.fromEntries(
-        Object.entries(record.permissions).map(
-          ([origin, { chain: permissionChain, addresses }]) => {
-            if (permissionChain === chain.toString()) {
-              return [origin, { addresses }];
-            } else {
-              return [origin, { addresses, chain: permissionChain }];
-            }
+        Object.entries(record.permissions).map(([origin, permission]) => {
+          if (permission.chain === chain.toString()) {
+            return [origin, { addresses: permission.addresses }];
+          } else {
+            return [origin, permission];
           }
-        )
+        })
       );
     });
   }

--- a/src/background/Wallet/WalletRecord.ts
+++ b/src/background/Wallet/WalletRecord.ts
@@ -723,15 +723,11 @@ export class WalletRecordModel {
     { chain }: { chain: Chain }
   ) {
     return produce(record, (draft) => {
-      draft.permissions = Object.fromEntries(
-        Object.entries(record.permissions).map(([origin, permission]) => {
-          if (permission.chain === chain.toString()) {
-            return [origin, { addresses: permission.addresses }];
-          } else {
-            return [origin, permission];
-          }
-        })
-      );
+      for (const permission of Object.values(draft.permissions)) {
+        if (permission.chain === chain.toString()) {
+          delete permission.chain;
+        }
+      }
     });
   }
 

--- a/src/background/Wallet/WalletRecord.ts
+++ b/src/background/Wallet/WalletRecord.ts
@@ -718,24 +718,21 @@ export class WalletRecordModel {
     return createChain(chain || NetworkId.Ethereum);
   }
 
-  static getPermissionsByChain(
-    record: WalletRecord,
-    { chain }: { chain: Chain }
-  ) {
-    return Object.entries(record.permissions)
-      .filter(([, permission]) => permission.chain === chain.toString())
-      .map(([origin, permission]) => ({ origin, permission }));
-  }
-
   static removeChainFromPermissions(
     record: WalletRecord,
     { chain }: { chain: Chain }
   ) {
     return produce(record, (draft) => {
       draft.permissions = Object.fromEntries(
-        Object.entries(record.permissions)
-          .filter(([, permission]) => permission.chain === chain.toString())
-          .map(([origin, { addresses }]) => [origin, { addresses }])
+        Object.entries(record.permissions).map(
+          ([origin, { chain: permissionChain, addresses }]) => {
+            if (permissionChain === chain.toString()) {
+              return [origin, { addresses }];
+            } else {
+              return [origin, { addresses, chain: permissionChain }];
+            }
+          }
+        )
       );
     });
   }

--- a/src/background/Wallet/WalletRecord.ts
+++ b/src/background/Wallet/WalletRecord.ts
@@ -718,6 +718,15 @@ export class WalletRecordModel {
     return createChain(chain || NetworkId.Ethereum);
   }
 
+  static getPermissionsByChain(
+    record: WalletRecord,
+    { chain }: { chain: Chain }
+  ) {
+    return Object.entries(record.permissions)
+      .filter(([, permission]) => permission.chain === chain.toString())
+      .map(([origin, permission]) => ({ origin, permission }));
+  }
+
   static removeChainFromPermissions(
     record: WalletRecord,
     { chain }: { chain: Chain }


### PR DESCRIPTION
Previously we reset `Permission.chain` to Ethereum. 
This PR adds a new function `removeChainWithoutAddressesFromPermissions` which deletes the chain only if there is no associated addresses. For those permissions that still have associated addresses the chain is reset to Ethereum.