### PR TITLE
Refactoring: remove extra call to verifyOverviewChain

### DIFF
--- a/src/background/Wallet/Wallet.ts
+++ b/src/background/Wallet/Wallet.ts
@@ -1150,10 +1150,7 @@ export class Wallet {
       // TODO: remove chain for origin in case new chain is not set
       this.setChainForOrigin(createChain(NetworkId.Ethereum), origin);
     });
-    this.removeEthereumChainConfig({
-      context,
-      params: { chain: chainStr },
-    });
+    this.resetEthereumChain({ context, params: { chain: chainStr } });
   }
 
   async addEthereumChain({
@@ -1184,7 +1181,7 @@ export class Wallet {
     return result;
   }
 
-  async removeEthereumChainConfig({
+  async resetEthereumChain({
     context,
     params: { chain: chainStr },
   }: WalletMethodParams<{ chain: string }>) {

--- a/src/background/Wallet/Wallet.ts
+++ b/src/background/Wallet/Wallet.ts
@@ -1150,7 +1150,10 @@ export class Wallet {
       // TODO: remove chain for origin in case new chain is not set
       this.setChainForOrigin(createChain(NetworkId.Ethereum), origin);
     });
-    this.resetEthereumChain({ context, params: { chain: chainStr } });
+    this.removeEthereumChainConfig({
+      context,
+      params: { chain: chainStr },
+    });
   }
 
   async addEthereumChain({
@@ -1181,7 +1184,7 @@ export class Wallet {
     return result;
   }
 
-  async resetEthereumChain({
+  async removeEthereumChainConfig({
     context,
     params: { chain: chainStr },
   }: WalletMethodParams<{ chain: string }>) {

--- a/src/background/Wallet/Wallet.ts
+++ b/src/background/Wallet/Wallet.ts
@@ -1150,7 +1150,6 @@ export class Wallet {
       // TODO: remove chain for origin in case new chain is not set
       this.setChainForOrigin(createChain(NetworkId.Ethereum), origin);
     });
-    this.verifyOverviewChain();
     this.resetEthereumChain({ context, params: { chain: chainStr } });
   }
 

--- a/src/ui/pages/Networks/Networks.tsx
+++ b/src/ui/pages/Networks/Networks.tsx
@@ -236,9 +236,7 @@ function NetworkPage() {
   });
   const resetMutation = useMutation({
     mutationFn: (network: NetworkConfig) =>
-      walletPort.request('removeEthereumChainConfig', {
-        chain: network.id,
-      }),
+      walletPort.request('resetEthereumChain', { chain: network.id }),
     onSuccess() {
       networksStore.update();
       navigate(-1);

--- a/src/ui/pages/Networks/Networks.tsx
+++ b/src/ui/pages/Networks/Networks.tsx
@@ -236,7 +236,9 @@ function NetworkPage() {
   });
   const resetMutation = useMutation({
     mutationFn: (network: NetworkConfig) =>
-      walletPort.request('resetEthereumChain', { chain: network.id }),
+      walletPort.request('removeEthereumChainConfig', {
+        chain: network.id,
+      }),
     onSuccess() {
       networksStore.update();
       navigate(-1);


### PR DESCRIPTION
- Removes extra call to `verifyOverviewChain`, since `resetEthereumChain` calls at as well
- Renames `resetEthereumChain` to `removeEthereumChainConfig`