### PR TITLE
Improve displaying symbol names

### DIFF
--- a/src/ui/components/AssetLink/AssetLink.tsx
+++ b/src/ui/components/AssetLink/AssetLink.tsx
@@ -28,7 +28,7 @@ export function AssetLink({
         outlineOffset: -1, // make focus ring visible despite overflow: hidden
       }}
     >
-      {title || asset.symbol?.toUpperCase() || asset.name}
+      {title || asset.symbol || asset.name}
     </TextAnchor>
   );
 }

--- a/src/ui/pages/SendForm/AssetSelect/AssetSelect.tsx
+++ b/src/ui/pages/SendForm/AssetSelect/AssetSelect.tsx
@@ -83,6 +83,7 @@ function ResultItem({ addressAsset }: { addressAsset: BareAddressPosition }) {
               style={{
                 gridTemplateColumns:
                   'minmax(min-content, max-content) auto 1fr',
+                whiteSpace: 'nowrap',
               }}
             >
               {details[0]}

--- a/src/ui/pages/SendForm/AssetSelect/AssetSelect.tsx
+++ b/src/ui/pages/SendForm/AssetSelect/AssetSelect.tsx
@@ -63,7 +63,18 @@ function ResultItem({ addressAsset }: { addressAsset: BareAddressPosition }) {
         image={
           <TokenIcon size={36} src={asset.icon_url} symbol={asset.symbol} />
         }
-        text={<UIText kind="body/accent">{asset.name}</UIText>}
+        text={
+          <UIText
+            kind="body/accent"
+            style={{
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+            }}
+          >
+            {asset.name}
+          </UIText>
+        }
         vGap={0}
         detailText={
           <UIText kind="small/regular" color="var(--neutral-700)">

--- a/src/ui/pages/SendForm/AssetSelect/AssetSelect.tsx
+++ b/src/ui/pages/SendForm/AssetSelect/AssetSelect.tsx
@@ -52,9 +52,11 @@ function ResultItem({ addressAsset }: { addressAsset: BareAddressPosition }) {
     })
   );
   const details = [
-    `${formatTokenValue(quantityCommon)} ${asset.symbol}`,
+    `${formatTokenValue(quantityCommon)}`,
+    asset.symbol,
     price ? formatCurrencyValue(price.value, 'en', 'usd') : null,
   ].filter(Boolean);
+
   return (
     <HStack gap={4} justifyContent="space-between" alignItems="center">
       <Media
@@ -65,9 +67,26 @@ function ResultItem({ addressAsset }: { addressAsset: BareAddressPosition }) {
         vGap={0}
         detailText={
           <UIText kind="small/regular" color="var(--neutral-700)">
-            {details[0]}
-            {details.length > 1 ? ' · ' : null}
-            {details[1]}
+            <HStack
+              gap={4}
+              style={{
+                gridTemplateColumns:
+                  'minmax(min-content, max-content) auto 1fr',
+              }}
+            >
+              {details[0]}
+              <div
+                style={{
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                }}
+              >
+                {details[1]}
+              </div>
+              {details.length > 2 ? ' · ' : null}
+              {details[2]}
+            </HStack>
           </UIText>
         }
       />
@@ -522,7 +541,11 @@ function AssetSelectComponent({
           })}
           {...(isCombobox ? {} : getInputProps())}
         >
-          <HStack gap={8} alignItems="center">
+          <HStack
+            gap={8}
+            alignItems="center"
+            style={{ overflowWrap: 'anywhere' }}
+          >
             <TokenIcon
               size={20}
               src={selectedItem.asset.icon_url}
@@ -538,7 +561,7 @@ function AssetSelectComponent({
                   selectedItem.asset.symbol.length > 8 ? '0.8em' : undefined,
               }}
             >
-              {selectedItem.asset.symbol.toUpperCase()}
+              {selectedItem.asset.symbol}
               <DownIcon
                 width={24}
                 height={24}

--- a/src/ui/pages/SendTransaction/TransactionWarnings/InsufficientFundsWarning.tsx
+++ b/src/ui/pages/SendTransaction/TransactionWarnings/InsufficientFundsWarning.tsx
@@ -59,7 +59,7 @@ export function InsufficientFundsWarning({
     <TransactionWarning
       title="Insufficient balance"
       message={`You don't have enough ${
-        networks?.getNetworkByName(chain)?.native_asset?.symbol.toUpperCase() ||
+        networks?.getNetworkByName(chain)?.native_asset?.symbol ||
         'native token'
       } to cover network fees`}
     />

--- a/src/ui/ui-kit/TokenIcon/TokenIcon.tsx
+++ b/src/ui/ui-kit/TokenIcon/TokenIcon.tsx
@@ -27,7 +27,7 @@ export function TokenIcon({ src, symbol, size = 32, style, title }: Props) {
         ...style,
       }}
     >
-      {symbol?.slice(0, 3).toLowerCase() || '?'}
+      {symbol?.slice(0, 3) || '???'}
     </UIText>
   );
   return src ? (


### PR DESCRIPTION
Get rid of `toLowerCase()` & `toUpperCase()` for symbols. Adjust CSS rules for long symbol names.