### PR TITLE
Refactor: minor changes for GlobalPreferences

### DIFF
--- a/src/background/ContentScriptManager.ts
+++ b/src/background/ContentScriptManager.ts
@@ -1,6 +1,5 @@
 import browser from 'webextension-polyfill';
 import { createNanoEvents } from 'nanoevents';
-import { produce } from 'immer';
 import { isTruthy } from 'is-truthy-ts';
 import {
   globalPreferences,
@@ -79,22 +78,7 @@ export class ContentScriptManager {
   }
 
   removeExpiredRecords() {
-    const now = Date.now();
-    globalPreferences.setState((state) =>
-      produce(state, (draft) => {
-        if (draft.providerInjection) {
-          for (const key in draft.providerInjection) {
-            const value = draft.providerInjection[key];
-            if (value && value.expires != null && value.expires <= now) {
-              delete draft.providerInjection[key];
-            }
-          }
-          if (Object.keys(draft.providerInjection).length === 0) {
-            delete draft.providerInjection;
-          }
-        }
-      })
-    );
+    globalPreferences.removeExpiredProviderInjections();
     return this;
   }
 

--- a/src/background/ContentScriptManager.ts
+++ b/src/background/ContentScriptManager.ts
@@ -121,7 +121,7 @@ export class ContentScriptManager {
   }
 
   activate() {
-    // TODO: may be call this.removeExpiredRecords() here instead of outside
+    this.removeExpiredRecords();
     this.handleChange();
     globalPreferences.on('change', this.handleChange.bind(this));
     globalPreferences.on('change', this.setAndDiscardAlarms.bind(this));

--- a/src/background/Wallet/GlobalPreferences.ts
+++ b/src/background/Wallet/GlobalPreferences.ts
@@ -1,4 +1,5 @@
 import throttle from 'lodash/throttle';
+import { produce } from 'immer';
 import { PersistentStore } from 'src/modules/persistent-store';
 import type { RemoteConfig } from 'src/modules/remote-config';
 import { getRemoteConfigValue } from 'src/modules/remote-config';
@@ -138,6 +139,25 @@ export class GlobalPreferences extends PersistentStore<State> {
       }
       return valueWithoutDefaults;
     });
+  }
+
+  removeExpiredProviderInjections() {
+    const now = Date.now();
+    this.setState((state) =>
+      produce(state, (draft) => {
+        if (draft.providerInjection) {
+          for (const key in draft.providerInjection) {
+            const value = draft.providerInjection[key];
+            if (value && value.expires != null && value.expires <= now) {
+              delete draft.providerInjection[key];
+            }
+          }
+          if (Object.keys(draft.providerInjection).length === 0) {
+            delete draft.providerInjection;
+          }
+        }
+      })
+    );
   }
 }
 

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -123,7 +123,7 @@ initialize().then((values) => {
   // const httpConnection = new HttpConnection(() => account.getCurrentWallet());
   const memoryCacheRPC = new MemoryCacheRPC();
 
-  new ContentScriptManager().removeExpiredRecords().activate();
+  new ContentScriptManager().activate();
 
   portRegistry.addMessageHandler(
     createWalletMessageHandler(() => account.getCurrentWallet())


### PR DESCRIPTION
* move removing of expired provider injections into `GlobalPreferences`
* move `removeExpiredRecords()` inside `activate()`

It feels like the removing of expired provider injections belongs to `GlobalPreferences` class, wdyt?