### PR TITLE
Improve switch chain error message

### DIFF
--- a/src/shared/errors/errors.ts
+++ b/src/shared/errors/errors.ts
@@ -86,7 +86,7 @@ export class SwitchChainError extends ErrorWithEnumerableMessage {
   code = 4902;
 
   constructor(
-    message = 'Unrecognized chain ID: Try adding the chain using wallet_addEthereumChain first.'
+    message = 'Unrecognized chainId: Try adding the chain using wallet_addEthereumChain first.'
   ) {
     super(message);
   }

--- a/src/shared/errors/errors.ts
+++ b/src/shared/errors/errors.ts
@@ -85,7 +85,9 @@ export class OriginNotAllowed extends ErrorWithEnumerableMessage {
 export class SwitchChainError extends ErrorWithEnumerableMessage {
   code = 4902;
 
-  constructor(message = 'Chain not configured') {
+  constructor(
+    message = 'Unrecognized chain ID: Try adding the chain using wallet_addEthereumChain first.'
+  ) {
     super(message);
   }
 }


### PR DESCRIPTION
It might be better to display a similar message for this error as we do for error 4100:
“Unrecognized chain ID. Try adding the chain using wallet_addEthereumChain first.”

This is consistent with MetaMask's error message: [MetaMask Docs](https://docs.metamask.io/wallet/reference/wallet_switchethereumchain/).