### PR TITLE
Allow users to keep current RPC url

### DIFF
--- a/src/ui/pages/AddEthereumChain/AddEthereumChain.tsx
+++ b/src/ui/pages/AddEthereumChain/AddEthereumChain.tsx
@@ -44,11 +44,13 @@ interface AddChainResult {
 function AddOrUpdateChain({
   origin,
   addEthereumChainParameterStringified,
+  onKeepCurrent,
   onReject,
   onSuccess,
 }: {
   origin: string;
   addEthereumChainParameterStringified: string;
+  onKeepCurrent: () => void;
   onReject: () => void;
   onSuccess: (value: AddChainResult) => void;
 }) {
@@ -163,7 +165,7 @@ function AddOrUpdateChain({
             prevNetwork={prevNetwork}
             rpcUrlHelpHref={`/addEthereumChain/what-is-rpc-url?${params}`}
             isSubmitting={addEthereumChainMutation.isLoading}
-            onCancel={onReject}
+            onKeepCurrent={onKeepCurrent}
             onSubmit={(networkId, result) => {
               addEthereumChainMutation.mutate({
                 networkId,
@@ -244,6 +246,7 @@ function AddEthereumChainContent({
         addEthereumChainParameterStringified
       }
       origin={origin}
+      onKeepCurrent={onDone}
       onReject={onReject}
       onSuccess={(result) => setResult(result)}
     />
@@ -261,6 +264,7 @@ export function AddEthereumChain() {
     addEthereumChainParameter,
     'addEtheretumChainParameter get-parameter is required for this view'
   );
+
   const handleReject = useCallback(
     () => windowPort.reject(windowId),
     [windowId]

--- a/src/ui/pages/AddEthereumChain/RpcUrlForm/RpcUrlForm.tsx
+++ b/src/ui/pages/AddEthereumChain/RpcUrlForm/RpcUrlForm.tsx
@@ -24,7 +24,7 @@ export function RpcUrlForm({
   prevNetwork,
   isSubmitting,
   onSubmit,
-  onCancel,
+  onKeepCurrent,
   rpcUrlHelpHref,
 }: {
   network: NetworkConfig;
@@ -32,7 +32,7 @@ export function RpcUrlForm({
   rpcUrlHelpHref: string;
   isSubmitting: boolean;
   onSubmit: (chain: string, result: AddEthereumChainParameter) => void;
-  onCancel: () => void;
+  onKeepCurrent: () => void;
 }) {
   const { networks } = useNetworks();
 
@@ -122,11 +122,11 @@ export function RpcUrlForm({
             gap: 8,
           }}
         >
-          <Button type="button" kind="regular" onClick={onCancel}>
-            Cancel
+          <Button type="button" kind="regular" onClick={onKeepCurrent}>
+            Keep Current
           </Button>
           <Button form={id} disabled={isSubmitting} kind="primary">
-            {isSubmitting ? 'Loading...' : 'Update'}
+            {isSubmitting ? 'Loading...' : 'Accept'}
           </Button>
         </div>
       </Content>


### PR DESCRIPTION
## Issue
When dapps suggest adding a network, and if the network already exists in the Extension, we suggest users update the RPC URL. If users don't accept the suggested change, they will be stuck.

This PR allows users to either keep the current RPC URL or accept a new one.

## Details
Previously, this issue could be reproduced on SyncSwap and Zora. Now, both dapps have been fixed, and it's no longer possible to replicate the issue. Regardless, this PR addresses such cases by preventing a `UserRejected` error.

The updated UI includes a "Keep Current" button that retains the existing RPC URL and returns `null`, simulating a successful chain addition as specified in [EIP-3085](https://eips.ethereum.org/EIPS/eip-3085).

## Regarding the case with https://play.cambria.gg/
Our wallet only shows the “Switch Network” dialog if the dApp requests a network change before the wallet is connected. However, this specific dApp always prompts for a connection if the wallet is not already connected (at least that is what happens to me :sweat_smile:).
Even if that’s the case, with [my fix in this build](https://github.com/zeriontech/zerion-wallet-extension/pull/525#issuecomment-2148603273), everything should stop after the second “Update network” dialog. This is because I now return null instead of throwing UserRejected error, which is legitimate according to the spec since we are actually changing the active network, even though we’re not changing the RPC URL