### PR TITLE
Fix: do not mutate tx object

### DIFF
--- a/src/ui/pages/SendTransaction/SendTransaction.tsx
+++ b/src/ui/pages/SendTransaction/SendTransaction.tsx
@@ -216,7 +216,7 @@ async function configureTransactionToSign<T extends IncomingTransaction>(
     chainGasPrices: ChainGasPrice | null;
   }
 ): Promise<PartiallyRequired<T, 'chainId' | 'from'>> {
-  let tx = transaction as T | IncomingTransaction;
+  let tx = { ...transaction } as T | IncomingTransaction;
 
   const chainId = transaction.chainId || networks.getChainId(chain);
   invariant(chainId, 'Could not resolve chainId for tx to sign');


### PR DESCRIPTION
Surprisingly, this lead to a bug in Brave only
in the production build
The readonly guard probably because tx comes through React props