### PR TITLE
Update license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "Wallet"
   ],
   "author": "everdimension <everdimension@gmail.com>",
-  "license": "ISC",
+  "license": "GPL-3.0-only",
   "bugs": {
     "url": "https://github.com/zeriontech/zerion-wallet-extension/issues"
   },


### PR DESCRIPTION
Right now the LICENSE file doesn't match the "license" field in the `package.json`

(I believe it's acceptable for the build to fail in this case because it fails due to secrets not being available in the GitHub workflow when triggered from a fork)