### PR TITLE
Fix asset selector styles

### DIFF
--- a/src/ui/pages/SendForm/AssetSelect/AssetSelect.tsx
+++ b/src/ui/pages/SendForm/AssetSelect/AssetSelect.tsx
@@ -551,15 +551,11 @@ function AssetSelectComponent({
             tabIndex: 0,
             type: 'button',
             className: styles.select,
-            style: { display: 'block' },
+            style: { display: 'block', overflowWrap: 'break-word' },
           })}
           {...(isCombobox ? {} : getInputProps())}
         >
-          <HStack
-            gap={8}
-            alignItems="center"
-            style={{ overflowWrap: 'anywhere' }}
-          >
+          <HStack gap={8} alignItems="center">
             <TokenIcon
               size={20}
               src={selectedItem.asset.icon_url}


### PR DESCRIPTION
Fixes asset selector (for Brave browser)

before/after:

<img width="470" alt="image" src="https://github.com/zeriontech/zerion-wallet-extension/assets/988849/1debbb8f-1d1f-4fe0-b2e9-7b1f7e931d40">
<img width="470" alt="image" src="https://github.com/zeriontech/zerion-wallet-extension/assets/988849/fe281e61-aef1-44f8-9454-d7a5b4e284ac">

---
(I believe it's acceptable for the build to fail in this case because it fails due to secrets not being available in the GitHub workflow when triggered from a fork)