### PR TITLE
Display application line, address & network icon in Send token form

### DIFF
--- a/src/ui/components/address-action/AddressActionDetails/AddressActionDetails.tsx
+++ b/src/ui/components/address-action/AddressActionDetails/AddressActionDetails.tsx
@@ -38,6 +38,7 @@ export function AddressActionDetails({
         <RecipientLine
           recipientAddress={recipientAddress}
           chain={chain}
+          showNetworkIcon={!showApplicationLine}
           networks={networks}
         />
       ) : null}

--- a/src/ui/components/address-action/AddressActionDetails/AddressActionDetails.tsx
+++ b/src/ui/components/address-action/AddressActionDetails/AddressActionDetails.tsx
@@ -32,14 +32,17 @@ export function AddressActionDetails({
   showApplicationLine: boolean;
   singleAssetElementEnd: React.ReactNode;
 }) {
-  const showNetworkIcon = !(showApplicationLine && addressAction?.label);
+  const applicationLineVisible = Boolean(
+    showApplicationLine && addressAction?.label
+  );
+
   return (
     <>
       {recipientAddress && addressAction?.type.value === 'send' ? (
         <RecipientLine
           recipientAddress={recipientAddress}
           chain={chain}
-          showNetworkIcon={showNetworkIcon}
+          showNetworkIcon={!applicationLineVisible}
           networks={networks}
         />
       ) : null}

--- a/src/ui/components/address-action/AddressActionDetails/AddressActionDetails.tsx
+++ b/src/ui/components/address-action/AddressActionDetails/AddressActionDetails.tsx
@@ -18,6 +18,7 @@ export function AddressActionDetails({
   actionTransfers,
   singleAsset,
   allowanceQuantityBase,
+  showApplicationLine,
   singleAssetElementEnd,
 }: {
   recipientAddress?: string;
@@ -28,6 +29,7 @@ export function AddressActionDetails({
   actionTransfers?: ActionTransfers;
   singleAsset?: NonNullable<AddressAction['content']>['single_asset'];
   allowanceQuantityBase: string | null;
+  showApplicationLine: boolean;
   singleAssetElementEnd: React.ReactNode;
 }) {
   return (
@@ -39,7 +41,7 @@ export function AddressActionDetails({
           networks={networks}
         />
       ) : null}
-      {addressAction?.label && addressAction?.label.type !== 'to' ? (
+      {showApplicationLine && addressAction?.label ? (
         <ApplicationLine
           action={addressAction}
           chain={chain}

--- a/src/ui/components/address-action/AddressActionDetails/AddressActionDetails.tsx
+++ b/src/ui/components/address-action/AddressActionDetails/AddressActionDetails.tsx
@@ -32,10 +32,7 @@ export function AddressActionDetails({
   showApplicationLine: boolean;
   singleAssetElementEnd: React.ReactNode;
 }) {
-  const applicationLineVisible = Boolean(
-    showApplicationLine && addressAction?.label
-  );
-
+  const applicationLineVisible = showApplicationLine && addressAction?.label;
   return (
     <>
       {recipientAddress && addressAction?.type.value === 'send' ? (
@@ -46,7 +43,7 @@ export function AddressActionDetails({
           networks={networks}
         />
       ) : null}
-      {showApplicationLine && addressAction?.label ? (
+      {applicationLineVisible ? (
         <ApplicationLine
           action={addressAction}
           chain={chain}

--- a/src/ui/components/address-action/AddressActionDetails/AddressActionDetails.tsx
+++ b/src/ui/components/address-action/AddressActionDetails/AddressActionDetails.tsx
@@ -32,13 +32,14 @@ export function AddressActionDetails({
   showApplicationLine: boolean;
   singleAssetElementEnd: React.ReactNode;
 }) {
+  const showNetworkIcon = !(showApplicationLine && addressAction?.label);
   return (
     <>
       {recipientAddress && addressAction?.type.value === 'send' ? (
         <RecipientLine
           recipientAddress={recipientAddress}
           chain={chain}
-          showNetworkIcon={!showApplicationLine}
+          showNetworkIcon={showNetworkIcon}
           networks={networks}
         />
       ) : null}

--- a/src/ui/components/address-action/ApplicationLine/ApplicationLine.tsx
+++ b/src/ui/components/address-action/ApplicationLine/ApplicationLine.tsx
@@ -1,8 +1,8 @@
 import { animated, useTransition } from '@react-spring/web';
 import { capitalize } from 'capitalize-ts';
-import { ethers } from 'ethers';
-import ArrowLeftTop from 'jsx:src/ui/assets/arrow-left-top.svg';
 import React, { useLayoutEffect, useState } from 'react';
+import ArrowLeftTop from 'jsx:src/ui/assets/arrow-left-top.svg';
+import { toChecksumAddress } from 'src/modules/ethereum/toChecksumAddress';
 import type { AnyAddressAction } from 'src/modules/ethereum/transactions/addressAction';
 import type { Chain } from 'src/modules/networks/Chain';
 import type { NetworkConfig } from 'src/modules/networks/NetworkConfig';
@@ -117,7 +117,7 @@ function getApplicationAddress(action: Pick<AnyAddressAction, 'label'>) {
   }
 
   try {
-    return ethers.utils.getAddress(action.label?.value);
+    return toChecksumAddress(action.label.value);
   } catch {
     return null;
   }

--- a/src/ui/components/address-action/ApplicationLine/ApplicationLine.tsx
+++ b/src/ui/components/address-action/ApplicationLine/ApplicationLine.tsx
@@ -1,22 +1,23 @@
-import React, { useLayoutEffect, useState } from 'react';
 import { animated, useTransition } from '@react-spring/web';
 import { capitalize } from 'capitalize-ts';
-import type { Chain } from 'src/modules/networks/Chain';
-import type { Networks } from 'src/modules/networks/Networks';
-import { Media } from 'src/ui/ui-kit/Media';
+import { ethers } from 'ethers';
 import ArrowLeftTop from 'jsx:src/ui/assets/arrow-left-top.svg';
-import { UIText } from 'src/ui/ui-kit/UIText';
-import { Image } from 'src/ui/ui-kit/MediaFallback';
+import React, { useLayoutEffect, useState } from 'react';
+import type { AnyAddressAction } from 'src/modules/ethereum/transactions/addressAction';
+import type { Chain } from 'src/modules/networks/Chain';
+import type { NetworkConfig } from 'src/modules/networks/NetworkConfig';
+import type { Networks } from 'src/modules/networks/Networks';
 import { BlockieImg } from 'src/ui/components/BlockieImg';
-import { HStack } from 'src/ui/ui-kit/HStack';
-import { TextAnchor } from 'src/ui/ui-kit/TextAnchor';
-import { truncateAddress } from 'src/ui/shared/truncateAddress';
-import { Surface } from 'src/ui/ui-kit/Surface';
 import { NetworkIcon } from 'src/ui/components/NetworkIcon';
 import { ShuffleText } from 'src/ui/components/ShuffleText';
-import type { AnyAddressAction } from 'src/modules/ethereum/transactions/addressAction';
-import type { NetworkConfig } from 'src/modules/networks/NetworkConfig';
 import { openInNewWindow } from 'src/ui/shared/openInNewWindow';
+import { truncateAddress } from 'src/ui/shared/truncateAddress';
+import { HStack } from 'src/ui/ui-kit/HStack';
+import { Media } from 'src/ui/ui-kit/Media';
+import { Image } from 'src/ui/ui-kit/MediaFallback';
+import { Surface } from 'src/ui/ui-kit/Surface';
+import { TextAnchor } from 'src/ui/ui-kit/TextAnchor';
+import { UIText } from 'src/ui/ui-kit/UIText';
 
 const FadeOutAndIn = ({
   src,
@@ -105,6 +106,23 @@ function ApplicationImage({
   );
 }
 
+function getApplicationAddress(action: Pick<AnyAddressAction, 'label'>) {
+  const contractAddress = action.label?.display_value.contract_address;
+  if (contractAddress) {
+    return contractAddress;
+  }
+
+  if (!action.label?.value) {
+    return null;
+  }
+
+  try {
+    return ethers.utils.getAddress(action.label?.value);
+  } catch {
+    return null;
+  }
+}
+
 export function ApplicationLine({
   action,
   chain,
@@ -114,8 +132,10 @@ export function ApplicationLine({
   chain: Chain;
   networks: Networks;
 }) {
-  const contractAddress = action.label?.display_value.contract_address;
   const network = networks.getNetworkByName(chain) || null;
+
+  // TODO: Remove this hacky fallback once we have backend support
+  const applicationAddress = getApplicationAddress(action);
 
   return (
     <Surface style={{ borderRadius: 8, padding: '10px 12px' }}>
@@ -136,28 +156,30 @@ export function ApplicationLine({
               <ShuffleText
                 text={
                   action.label?.display_value.text ||
-                  (contractAddress ? truncateAddress(contractAddress, 4) : '')
+                  (applicationAddress
+                    ? truncateAddress(applicationAddress, 4)
+                    : '')
                 }
               />
             </UIText>
-            {contractAddress ? (
+            {applicationAddress ? (
               <UIText
                 kind="small/regular"
                 color="var(--neutral-500)"
-                title={contractAddress}
+                title={applicationAddress}
               >
                 <TextAnchor
                   // Open URL in a new _window_ so that extension UI stays open and visible
                   onClick={openInNewWindow}
                   href={networks.getExplorerAddressUrlByName(
                     chain,
-                    contractAddress
+                    applicationAddress
                   )}
                   target="_blank"
                   rel="noopener noreferrer"
                 >
                   <HStack gap={3} justifyContent="center" alignItems="center">
-                    <span>{truncateAddress(contractAddress, 4)}</span>
+                    <span>{truncateAddress(applicationAddress, 4)}</span>
                     <ArrowLeftTop />
                   </HStack>
                 </TextAnchor>

--- a/src/ui/components/address-action/RecipientLine/RecipientLine.tsx
+++ b/src/ui/components/address-action/RecipientLine/RecipientLine.tsx
@@ -9,16 +9,21 @@ import { TextAnchor } from 'src/ui/ui-kit/TextAnchor';
 import { UIText } from 'src/ui/ui-kit/UIText';
 import { openInNewWindow } from 'src/ui/shared/openInNewWindow';
 import { toChecksumAddress } from 'src/modules/ethereum/toChecksumAddress';
+import { NetworkIcon } from '../../NetworkIcon';
 
 export function RecipientLine({
   recipientAddress,
   chain,
   networks,
+  showNetworkIcon,
 }: {
   recipientAddress: string;
   chain: Chain;
   networks: Networks;
+  showNetworkIcon: boolean;
 }) {
+  const network = networks.getNetworkByName(chain) || null;
+
   const checksumAddress = useMemo(
     () => toChecksumAddress(recipientAddress),
     [recipientAddress]
@@ -27,7 +32,25 @@ export function RecipientLine({
     <Surface style={{ borderRadius: 8, padding: '10px 12px' }}>
       <Media
         image={
-          <BlockieImg address={checksumAddress} size={36} borderRadius={6} />
+          <div
+            style={{
+              position: 'relative',
+
+              width: 36,
+              height: 36,
+            }}
+          >
+            <BlockieImg address={checksumAddress} size={36} borderRadius={6} />
+            {showNetworkIcon ? (
+              <div style={{ position: 'absolute', bottom: 0, right: 0 }}>
+                <NetworkIcon
+                  size={16}
+                  name={network?.name || null}
+                  src={network?.icon_url || ''}
+                />
+              </div>
+            ) : null}
+          </div>
         }
         vGap={0}
         text={

--- a/src/ui/components/address-action/RecipientLine/RecipientLine.tsx
+++ b/src/ui/components/address-action/RecipientLine/RecipientLine.tsx
@@ -35,7 +35,6 @@ export function RecipientLine({
           <div
             style={{
               position: 'relative',
-
               width: 36,
               height: 36,
             }}

--- a/src/ui/components/address-action/RecipientLine/RecipientLine.tsx
+++ b/src/ui/components/address-action/RecipientLine/RecipientLine.tsx
@@ -32,13 +32,7 @@ export function RecipientLine({
     <Surface style={{ borderRadius: 8, padding: '10px 12px' }}>
       <Media
         image={
-          <div
-            style={{
-              position: 'relative',
-              width: 36,
-              height: 36,
-            }}
-          >
+          <div style={{ position: 'relative' }}>
             <BlockieImg address={checksumAddress} size={36} borderRadius={6} />
             {showNetworkIcon ? (
               <div style={{ position: 'absolute', bottom: 0, right: 0 }}>

--- a/src/ui/components/address-action/TransactionConfirmationView/TransactionConfirmationView.tsx
+++ b/src/ui/components/address-action/TransactionConfirmationView/TransactionConfirmationView.tsx
@@ -19,6 +19,7 @@ import { TransactionSimulation } from '../TransactionSimulation';
 export function TransactionConfirmationView({
   title,
   wallet,
+  showApplicationLine,
   transaction,
   chain,
   configuration,
@@ -28,6 +29,7 @@ export function TransactionConfirmationView({
 }: {
   title: React.ReactNode;
   wallet: ExternallyOwnedAccount;
+  showApplicationLine: boolean;
   transaction: IncomingTransactionWithChainId;
   chain: Chain;
   configuration: CustomConfiguration;
@@ -67,6 +69,7 @@ export function TransactionConfirmationView({
         style={{ display: 'flex', flexDirection: 'column' }}
       >
         <TransactionSimulation
+          showApplicationLine={showApplicationLine}
           localAllowanceQuantityBase={localAllowanceQuantityBase}
           onOpenAllowanceForm={onOpenAllowanceForm}
           address={wallet.address}

--- a/src/ui/components/address-action/TransactionSimulation/TransactionSimulation.tsx
+++ b/src/ui/components/address-action/TransactionSimulation/TransactionSimulation.tsx
@@ -28,6 +28,7 @@ export function TransactionSimulation({
   transaction,
   paymasterEligible,
   localAllowanceQuantityBase,
+  showApplicationLine,
   onOpenAllowanceForm,
 }: {
   vGap?: number;
@@ -35,6 +36,7 @@ export function TransactionSimulation({
   transaction: IncomingTransactionWithChainId;
   paymasterEligible: boolean;
   localAllowanceQuantityBase?: string;
+  showApplicationLine: boolean;
   onOpenAllowanceForm?: () => void;
 }) {
   const { networks } = useNetworks();
@@ -167,6 +169,7 @@ export function TransactionSimulation({
         actionTransfers={actionTransfers}
         singleAsset={singleAsset}
         allowanceQuantityBase={allowanceQuantityBase || null}
+        showApplicationLine={showApplicationLine}
         singleAssetElementEnd={
           allowanceQuantityBase && onOpenAllowanceForm ? (
             <UnstyledButton

--- a/src/ui/pages/SendForm/SendTransactionConfirmation/SendTransactionConfirmation.tsx
+++ b/src/ui/pages/SendForm/SendTransactionConfirmation/SendTransactionConfirmation.tsx
@@ -50,6 +50,7 @@ export function SendTransactionConfirmation({
     <TransactionConfirmationView
       title="Send"
       wallet={wallet}
+      showApplicationLine={false}
       chain={chain}
       transaction={transaction as IncomingTransactionWithChainId}
       configuration={sendView.store.configuration.getState()}

--- a/src/ui/pages/SendTransaction/SendTransaction.tsx
+++ b/src/ui/pages/SendTransaction/SendTransaction.tsx
@@ -387,6 +387,7 @@ function TransactionDefaultView({
           actionTransfers={actionTransfers}
           singleAsset={singleAsset}
           allowanceQuantityBase={allowanceQuantityBase}
+          showApplicationLine={true}
           singleAssetElementEnd={
             allowanceQuantityBase && addressAction.type.value === 'approve' ? (
               <UIText

--- a/src/ui/pages/SignTypedData/SignTypedData.tsx
+++ b/src/ui/pages/SignTypedData/SignTypedData.tsx
@@ -275,6 +275,7 @@ function TypedDataDefaultView({
             wallet={wallet}
             singleAsset={addressAction?.content?.single_asset}
             allowanceQuantityBase={allowanceQuantityBase || null}
+            showApplicationLine={true}
             singleAssetElementEnd={
               allowanceQuantityBase &&
               addressAction.type.value === 'approve' ? (

--- a/src/ui/pages/SwapForm/SwapForm.tsx
+++ b/src/ui/pages/SwapForm/SwapForm.tsx
@@ -552,6 +552,7 @@ export function SwapFormComponent() {
                     : 'Trade'
                 }
                 wallet={wallet}
+                showApplicationLine={true}
                 chain={chain}
                 transaction={configureTransactionToBeSigned(currentTransaction)}
                 configuration={swapView.store.configuration.getState()}


### PR DESCRIPTION
## Summary

Enhances the "send token" form and "send transaction" screens by adding visual elements to improve UX and clarity.
Fixes missing application line in `SendTransaction`.

## Changes

* `ApplicationLine`: displays the application line for transactions
* Introduced `showApplicationLine` flag to control the display in send, swap, and transaction forms
* Adds a network icon to the recipient line, displayed conditionally
