### PR TITLE
Delete origins with no active addresses from connections

### DIFF
--- a/src/background/Wallet/WalletRecord.ts
+++ b/src/background/Wallet/WalletRecord.ts
@@ -751,12 +751,7 @@ export class WalletRecordModel {
         existingPermissions.length = 0;
       }
       if (existingPermissions.length === 0) {
-        if (!permission.chain || permission.chain === NetworkId.Ethereum) {
-          // remove whole record for `origin` completely
-          delete draft.permissions[origin];
-        } else {
-          draft.permissions[origin].addresses = [];
-        }
+        delete draft.permissions[origin];
       }
     });
   }


### PR DESCRIPTION
Otherwise, it can be confusing to see dApps with no connected addresses:
![image](https://github.com/zeriontech/zerion-wallet-extension/assets/988849/111f37ca-6d8f-4bef-b173-b94f4581a46c)
![image](https://github.com/zeriontech/zerion-wallet-extension/assets/988849/aad05e27-65b6-43e5-b6a2-a6ece1e4c385)

Previously, we only deleted the entire record for disconnected origins (dApps) if there was no chain or if the chain was Ethereum. This PR removes that constraint, ensuring we always remove the entire record if there are no connected addresses left.