### PR TITLE
Remove unused GasPriceWithBaseObject type

### DIFF
--- a/src/modules/ethereum/transactions/gasPrices/GasPriceObject.ts
+++ b/src/modules/ethereum/transactions/gasPrices/GasPriceObject.ts
@@ -1,5 +1,4 @@
 import type { EIP1559 } from '@zeriontech/transactions';
-import type { EIP1559Base } from './EIP1559';
 
 export interface GasPriceObject {
   classic: number | string | null;
@@ -7,9 +6,4 @@ export interface GasPriceObject {
   optimistic: {
     underlying: { classic: number | string | null; eip1559: EIP1559 | null };
   } | null;
-}
-
-export interface GasPriceWithBaseObject {
-  classic?: number | string;
-  eip1559?: EIP1559Base;
 }


### PR DESCRIPTION
Not sure if it's necessary, as it's not currently being used anywhere