### PR TITLE
Fallback to null in queryFn

### DIFF
--- a/src/modules/networks/useNetworks.ts
+++ b/src/modules/networks/useNetworks.ts
@@ -89,7 +89,7 @@ export function useMainnetNetwork({
       const network = mainNetworksStore
         .getState()
         .networks?.getNetworkByName(createChain(chainStr));
-      return network;
+      return network ?? null;
     },
     staleTime: 1000 * 60 * 5,
     suspense: false,


### PR DESCRIPTION
Fallback to `null` to fix errors like these:
```
Query data cannot be undefined.
Please make sure to return a value other than undefined from your query function.
Affected query key: ["getMainnetworkItem","All"]
```
