### PR TITLE
Sanitize PR number from artifact

### DIFF
--- a/.github/workflows/pr_attach_build.yml
+++ b/.github/workflows/pr_attach_build.yml
@@ -65,9 +65,11 @@ jobs:
       - name: Attach build artifacts to the PR thread
         if: ${{ github.event.workflow_run.conclusion == 'success' }}
         uses: actions/github-script@v3
+        env:
+          PR_NUMBER:  "${{ steps.get-build-artifacts.outputs.pr_number }}"
         with:
           script: |
-            const pr_number = "${{ steps.get-build-artifacts.outputs.pr_number }}";
+            const pr_number = process.env.PR_NUMBER;
             const build_download_url = "${{ steps.get-build-artifacts.outputs.build_download_url }}";
             const message = `:package: <a href='${build_download_url}'>build.zip</a>`;
 


### PR DESCRIPTION
Technically the PR number could be anything from the first workflow if from a PR and therefore could be used to inject code. This fixes it.