### PR TITLE
Fix potential persistence issue

### DIFF
--- a/src/modules/crypto/aes.test.ts
+++ b/src/modules/crypto/aes.test.ts
@@ -1,0 +1,34 @@
+import { decrypt, encrypt } from './aes';
+
+describe('encrypt function', () => {
+  test('encrypted value is the same after decryption', async () => {
+    const value = { name: 'apple' };
+
+    const password = 'test-123';
+    const encrypted = await encrypt(password, value);
+    expect(encrypted).not.toBe(JSON.stringify(value));
+
+    const decrypted = await decrypt(password, encrypted);
+    expect(decrypted).toEqual(value);
+  });
+
+  test('very large value is encrypted correctly', async () => {
+    function createVeryLargeString() {
+      // A large string will at some point be split into bytes by the encrypting function
+      // and those bytes may be passed as arguments, but browsers have a different
+      // limit on maximum number of agruments: https://stackoverflow.com/a/22747272/3523645
+      // As a solution we avoid doing that and have this test as a guard, but its outcome
+      // may differ across javascript environments
+      const uint8Array = crypto.getRandomValues(new Uint8Array(65536));
+      return uint8Array.reduce((str, c) => str + String.fromCharCode(c), '');
+    }
+    const largeValue = { message: createVeryLargeString() };
+
+    const password = 'test-123';
+    const encrypted = await encrypt(password, largeValue);
+    expect(encrypted).not.toBe(JSON.stringify(largeValue));
+
+    const decrypted = await decrypt(password, encrypted);
+    expect(decrypted).toEqual(largeValue);
+  });
+});

--- a/src/modules/crypto/convert.ts
+++ b/src/modules/crypto/convert.ts
@@ -21,10 +21,12 @@ export function base64ToUint8Array(base64: string) {
 }
 
 export function uint8ArrayToBase64(array: Uint8Array) {
-  // Explicit casting is needed to satisfy the typechecker
-  return globalThis.btoa(
-    String.fromCharCode.apply(null, array as unknown as number[])
-  );
+  let str = '';
+  const length = array.byteLength;
+  for (let i = 0; i < length; i++) {
+    str += String.fromCharCode(array[i]);
+  }
+  return globalThis.btoa(str);
 }
 
 export function arrayBufferToBase64(buffer: ArrayBuffer) {


### PR DESCRIPTION
Fix RangeError when converting array buffer to base64 for large arrays. Using String.fromCharCodeApply(null, array) may cause too many arguments to be passed