### PR TITLE
Update manifest-version.js

### DIFF
--- a/scripts/manifest-version.js
+++ b/scripts/manifest-version.js
@@ -9,7 +9,7 @@ const src = path.join(__dirname, '../src');
 
 function toManifestVersion(version) {
   // turns value like "v1.0.1-alpha.23" to "1.0.0.23"
-  return version.replace(/[^\d.]+/g, '');
+  return version.replace(/^v|\D+\d+/g, '');
 }
 
 async function syncVersion() {


### PR DESCRIPTION
The code contains an error in the `toManifestVersion` function's `replace` method. The comment indicates the intention to transform a version string like "`v1.0.1-alpha.23`" into "`1.0.1.23`", but the current `replace` pattern (`/[^\d.]+/g`) will match and remove any non-numeric characters, including dots immediately following them, resulting in `1.0.0.23`.

Solution: Used a more targeted regular expression pattern to remove only the prefix and suffix.