### PR TITLE
Fix eth_getBalance request

### DIFF
--- a/src/modules/ethereum/eth_getBalance.ts
+++ b/src/modules/ethereum/eth_getBalance.ts
@@ -6,7 +6,7 @@ export async function eth_getBalance(
 ): Promise<string> {
   const { result: balanceInHex } = await sendRpcRequest<string>(url, {
     method: 'eth_getBalance',
-    params: [address],
+    params: [address, 'latest'],
   });
   const balance = BigInt(balanceInHex).toString();
   return balance;


### PR DESCRIPTION
Some rpc endpoints require the second param for this request
Example: https://chainlist.org/chain/420042