### PR TITLE
Show High Price impact warning + native bridge hint

### DIFF
--- a/src/shared/analytics/analytics.background.ts
+++ b/src/shared/analytics/analytics.background.ts
@@ -165,6 +165,8 @@ function trackAppEvents({ account }: { account: Account }) {
         clientScope,
         chain,
         outputChain,
+        warningWasShown = false,
+        outputAmountColor = 'grey',
       }
     ) => {
       const initiatorURL = new URL(initiator);
@@ -199,6 +201,8 @@ function trackAppEvents({ account }: { account: Account }) {
         network_fee_value: feeValueCommon,
         contract_type: quote ? quote.contractMetadata.name ?? null : null,
         hold_sign_button: Boolean(preferences.enableHoldToSignButton),
+        warning_was_shown: warningWasShown,
+        output_amount_color: outputAmountColor,
         ...omitNullParams(addressActionAnalytics),
       });
       sendToMetabase('signed_transaction', params);

--- a/src/shared/analytics/shared/addressActionToAnalytics.ts
+++ b/src/shared/analytics/shared/addressActionToAnalytics.ts
@@ -121,11 +121,11 @@ export function addressActionToAnalytics({
     const zerion_fee_usd_amount =
       quote.protocolFee.amount.usdValue ?? undefined;
     const network_fee = quote.networkFee?.amount?.usdValue ?? undefined;
-    const currentTransaction =
+    const currentTransactionEvm =
       quote.transactionSwap?.evm || quote.transactionApprove?.evm;
     const gas_price =
-      currentTransaction?.gasPrice != null
-        ? Number(currentTransaction.gasPrice)
+      currentTransactionEvm?.gasPrice != null
+        ? Number(currentTransactionEvm.gasPrice)
         : undefined;
 
     return {

--- a/src/shared/analytics/shared/addressActionToAnalytics.ts
+++ b/src/shared/analytics/shared/addressActionToAnalytics.ts
@@ -21,6 +21,8 @@ interface AnalyticsTransactionData {
   zerion_fee_percentage?: number;
   zerion_fee_usd_amount?: number;
   output_chain?: string;
+  network_fee?: number;
+  gas_price?: number;
 }
 
 interface AssetQuantity {
@@ -116,17 +118,22 @@ export function addressActionToAnalytics({
   };
   if (quote) {
     const zerion_fee_percentage = quote.protocolFee.percentage;
-    const feeAmount = quote.protocolFee.amount.quantity;
-    const asset = incoming?.[0]?.asset;
     const zerion_fee_usd_amount =
-      feeAmount && asset
-        ? assetQuantityToValue({ quantity: feeAmount, asset }, chain)
+      quote.protocolFee.amount.usdValue ?? undefined;
+    const network_fee = quote.networkFee?.amount?.usdValue ?? undefined;
+    const currentTransaction =
+      quote.transactionSwap?.evm || quote.transactionApprove?.evm;
+    const gas_price =
+      currentTransaction?.gasPrice != null
+        ? Number(currentTransaction.gasPrice)
         : undefined;
 
     return {
       ...value,
       zerion_fee_percentage,
       zerion_fee_usd_amount,
+      network_fee,
+      gas_price,
       output_chain: outputChain ?? undefined,
     };
   } else {

--- a/src/shared/types/SignatureContextParams.ts
+++ b/src/shared/types/SignatureContextParams.ts
@@ -15,6 +15,8 @@ export type TransactionContextParams = {
   initiator: string;
   clientScope: ClientScope | null;
   addressAction: AnyAddressAction | null;
+  warningWasShown?: boolean;
+  outputAmountColor?: 'grey' | 'red';
   /**
    * Currenly only applies to Solana dapp requests
    * This indicates the method that the dapp called originally

--- a/src/ui/components/FiatInputValue/FiatInputValue.tsx
+++ b/src/ui/components/FiatInputValue/FiatInputValue.tsx
@@ -84,13 +84,12 @@ export function SpendFiatInputValue(props: FieldInputValueProps) {
 
 export function ReceiveFiatInputValue({
   priceImpact,
+  showPriceImpactWarning,
   ...props
 }: {
+  showPriceImpactWarning: boolean;
   priceImpact: PriceImpact | null;
 } & FieldInputValueProps) {
-  const isSignificantLoss =
-    priceImpact?.kind === 'loss' &&
-    (priceImpact.level === 'medium' || priceImpact.level === 'high');
   const isProfit = priceImpact?.kind === 'profit';
 
   const priceImpactPercentage = priceImpact
@@ -108,7 +107,7 @@ export function ReceiveFiatInputValue({
   const percentageChangeVisible =
     Boolean(percentageChange) && priceImpact?.kind !== 'n/a';
 
-  const priceImpactColor = isSignificantLoss
+  const priceImpactColor = showPriceImpactWarning
     ? 'var(--negative-500)'
     : isProfit
     ? 'var(--positive-500)'
@@ -126,9 +125,9 @@ export function ReceiveFiatInputValue({
         ) : null
       }
       color={priceImpactColor}
-      style={isSignificantLoss ? { cursor: 'help' } : undefined}
+      style={showPriceImpactWarning ? { cursor: 'help' } : undefined}
       title={
-        isSignificantLoss
+        showPriceImpactWarning
           ? 'The exchange rate is lower than the market rate. Lack of liquidity affects the exchange rate. Try a lower amount.'
           : undefined
       }

--- a/src/ui/pages/BridgeForm/BridgeForm.tsx
+++ b/src/ui/pages/BridgeForm/BridgeForm.tsx
@@ -1149,12 +1149,7 @@ function BridgeFormComponent() {
             />
           ) : null}
         </VStack>
-        {isUK ? (
-          <>
-            <UKDisclaimer />
-            <Spacer height={8} />
-          </>
-        ) : null}
+        {isUK ? <UKDisclaimer /> : null}
         {selectedQuote?.error?.message ? (
           <TransactionWarning
             title="Warning"

--- a/src/ui/pages/BridgeForm/BridgeForm.tsx
+++ b/src/ui/pages/BridgeForm/BridgeForm.tsx
@@ -96,6 +96,8 @@ import { useUKDetection } from 'src/ui/components/UKDisclaimer/useUKDetection';
 import { UKDisclaimer } from 'src/ui/components/UKDisclaimer/UKDisclaimer';
 import { ErrorMessage } from 'src/ui/shared/error-display/ErrorMessage';
 import { getError } from 'get-error';
+import { TextAnchor } from 'src/ui/ui-kit/TextAnchor';
+import { openInNewWindow } from 'src/ui/shared/openInNewWindow';
 import { TransactionConfiguration } from '../SendTransaction/TransactionConfiguration';
 import { ApproveHintLine } from '../SwapForm/ApproveHintLine';
 import { getQuotesErrorMessage } from '../SwapForm/Quotes/getQuotesErrorMessage';
@@ -105,6 +107,9 @@ import { fromConfiguration, toConfiguration } from '../SendForm/shared/helpers';
 import { NetworkFeeLineInfo } from '../SendTransaction/TransactionConfiguration/TransactionConfiguration';
 import type { PopoverToastHandle } from '../Settings/PopoverToast';
 import { PopoverToast } from '../Settings/PopoverToast';
+import { PriceImpactLine } from '../SwapForm/shared/PriceImpactLine';
+import { calculatePriceImpact } from '../SwapForm/shared/price-impact';
+import { TransactionWarning } from '../SendTransaction/TransactionWarnings/TransactionWarning';
 import type { BridgeFormState } from './types';
 import { ReverseButton } from './ReverseButton';
 import { SpendTokenField } from './fieldsets/SpendTokenField';
@@ -404,6 +409,34 @@ function BridgeNetworksSelect({
   );
 }
 
+function NativeZeroBridgeHint() {
+  return (
+    <VStack
+      gap={8}
+      style={{
+        padding: 16,
+        borderRadius: 8,
+        border: '1px solid var(--notice-500)',
+      }}
+    >
+      <UIText kind="small/regular" color="var(--notice-500)">
+        It seems there is a lack of liquidity, if you are not in a hurry and
+        want a better quote, use:
+      </UIText>
+      <UIText kind="small/accent" color="var(--primary)">
+        <TextAnchor
+          onClick={openInNewWindow}
+          href="https://bridge.zero.network/bridge/withdraw"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          bridge.zero.network
+        </TextAnchor>
+      </UIText>
+    </VStack>
+  );
+}
+
 function BridgeFormComponent() {
   useBackgroundKind(whiteBackgroundKind);
 
@@ -586,6 +619,15 @@ function BridgeFormComponent() {
   }, [userQuoteId, quotesData.quotes]);
 
   const outputAmount = selectedQuote?.outputAmount.quantity || null;
+
+  const priceImpact = useMemo(() => {
+    return calculatePriceImpact({
+      inputValue: inputAmount || null,
+      outputValue: outputAmount || null,
+      inputAsset: inputPosition?.asset ?? null,
+      outputAsset: outputPosition?.asset ?? null,
+    });
+  }, [inputAmount, inputPosition?.asset, outputAmount, outputPosition?.asset]);
 
   /** Same as handleChange, but reverses chains if selected chain is same as the opposite one */
   const handleChainChange = useEvent<HandleChangeFunction>((key, value) => {
@@ -787,6 +829,18 @@ function BridgeFormComponent() {
       />
     );
   }
+
+  const showPriceImpactWarning =
+    priceImpact?.kind === 'loss' &&
+    (priceImpact.level === 'medium' || priceImpact.level === 'high');
+
+  /**
+   * Show native zero bridge hint when: there is low liquidity or no liquidity at all
+   */
+  const showNativeZeroBridgeHint =
+    inputChain === NetworkId.Zero &&
+    (quotesData.done || quotesData.error) &&
+    (!selectedQuote || showPriceImpactWarning);
 
   return (
     <PageColumn>
@@ -1000,6 +1054,7 @@ function BridgeFormComponent() {
               spendInput={inputAmount ?? undefined}
               spendAsset={inputPosition?.asset ?? null}
               onChangeToken={(value) => handleChange('outputFungibleId', value)}
+              priceImpact={priceImpact}
             />
             <ReceiverAddressField
               title={
@@ -1100,6 +1155,16 @@ function BridgeFormComponent() {
             <Spacer height={8} />
           </>
         ) : null}
+        {selectedQuote?.error?.message ? (
+          <TransactionWarning
+            title="Warning"
+            message={selectedQuote?.error?.message}
+          />
+        ) : null}
+        {quotesData.done && priceImpact && !isApproveMode ? (
+          <PriceImpactLine priceImpact={priceImpact} />
+        ) : null}
+        {showNativeZeroBridgeHint ? <NativeZeroBridgeHint /> : null}
       </VStack>
       <div style={{ position: 'relative', width: '100%', textAlign: 'center' }}>
         <HiddenValidationInput

--- a/src/ui/pages/BridgeForm/BridgeForm.tsx
+++ b/src/ui/pages/BridgeForm/BridgeForm.tsx
@@ -730,6 +730,16 @@ function BridgeFormComponent() {
     snapshotRef.current = formState;
   };
 
+  const showPriceImpactCallout =
+    quotesData.done &&
+    !isApproveMode &&
+    priceImpact?.kind === 'loss' &&
+    priceImpact.level === 'high';
+
+  const showPriceImpactWarning =
+    priceImpact?.kind === 'loss' &&
+    (priceImpact.level === 'medium' || priceImpact.level === 'high');
+
   const { mutate: sendTransaction, ...sendTransactionMutation } = useMutation({
     mutationFn: async (
       interpretationAction: AddressAction | null
@@ -770,6 +780,8 @@ function BridgeFormComponent() {
         addressAction: interpretationAction ?? fallbackAddressAction,
         quote: selectedQuote,
         outputChain: outputChain ?? null,
+        warningWasShown: Boolean(showPriceImpactCallout),
+        outputAmountColor: showPriceImpactWarning ? 'red' : 'grey',
       });
       return txResponse;
     },
@@ -829,10 +841,6 @@ function BridgeFormComponent() {
       />
     );
   }
-
-  const showPriceImpactWarning =
-    priceImpact?.kind === 'loss' &&
-    (priceImpact.level === 'medium' || priceImpact.level === 'high');
 
   /**
    * Show native zero bridge hint when: there is low liquidity or no liquidity at all
@@ -1055,6 +1063,7 @@ function BridgeFormComponent() {
               spendAsset={inputPosition?.asset ?? null}
               onChangeToken={(value) => handleChange('outputFungibleId', value)}
               priceImpact={priceImpact}
+              showPriceImpactWarning={showPriceImpactWarning}
             />
             <ReceiverAddressField
               title={
@@ -1088,7 +1097,7 @@ function BridgeFormComponent() {
       </form>
 
       <Spacer height={16} />
-      <VStack gap={8}>
+      <VStack gap={8} style={{ paddingBottom: 8 }}>
         <VStack
           gap={8}
           style={
@@ -1156,7 +1165,7 @@ function BridgeFormComponent() {
             message={selectedQuote?.error?.message}
           />
         ) : null}
-        {quotesData.done && priceImpact && !isApproveMode ? (
+        {showPriceImpactCallout ? (
           <PriceImpactLine priceImpact={priceImpact} />
         ) : null}
         {showNativeZeroBridgeHint ? <NativeZeroBridgeHint /> : null}

--- a/src/ui/pages/BridgeForm/BridgeForm.tsx
+++ b/src/ui/pages/BridgeForm/BridgeForm.tsx
@@ -97,7 +97,6 @@ import { UKDisclaimer } from 'src/ui/components/UKDisclaimer/UKDisclaimer';
 import { ErrorMessage } from 'src/ui/shared/error-display/ErrorMessage';
 import { getError } from 'get-error';
 import { TextAnchor } from 'src/ui/ui-kit/TextAnchor';
-import { openInNewWindow } from 'src/ui/shared/openInNewWindow';
 import { TransactionConfiguration } from '../SendTransaction/TransactionConfiguration';
 import { ApproveHintLine } from '../SwapForm/ApproveHintLine';
 import { getQuotesErrorMessage } from '../SwapForm/Quotes/getQuotesErrorMessage';
@@ -425,7 +424,6 @@ function NativeZeroBridgeHint() {
       </UIText>
       <UIText kind="small/accent" color="var(--primary)">
         <TextAnchor
-          onClick={openInNewWindow}
           href="https://bridge.zero.network/bridge/withdraw"
           target="_blank"
           rel="noopener noreferrer"

--- a/src/ui/pages/BridgeForm/fieldsets/ReceiveTokenField/ReceiveTokenField.tsx
+++ b/src/ui/pages/BridgeForm/fieldsets/ReceiveTokenField/ReceiveTokenField.tsx
@@ -25,6 +25,7 @@ export function ReceiveTokenField({
   spendAsset,
   onChangeToken,
   priceImpact,
+  showPriceImpactWarning,
 }: {
   receiveInput?: string;
   receiveChain: Chain | null;
@@ -34,6 +35,7 @@ export function ReceiveTokenField({
   spendAsset: Asset | null;
   onChangeToken: (value: string) => void;
   priceImpact: PriceImpact | null;
+  showPriceImpactWarning: boolean;
 }) {
   const positionBalanceCommon = receivePosition
     ? getPositionBalance(receivePosition)
@@ -118,6 +120,7 @@ export function ReceiveTokenField({
             receiveInput={receiveInput}
             receiveAsset={receivePosition?.asset ?? null}
             priceImpact={priceImpact}
+            showPriceImpactWarning={showPriceImpactWarning}
           />
         }
       />

--- a/src/ui/pages/BridgeForm/fieldsets/ReceiveTokenField/ReceiveTokenField.tsx
+++ b/src/ui/pages/BridgeForm/fieldsets/ReceiveTokenField/ReceiveTokenField.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useId, useMemo, useRef } from 'react';
+import React, { useEffect, useId, useRef } from 'react';
 import { getPositionBalance } from 'src/ui/components/Positions/helpers';
 import {
   formatTokenValue,
@@ -14,7 +14,7 @@ import type { AddressPosition, Asset } from 'defi-sdk';
 import { MarketAssetSelect } from 'src/ui/pages/SwapForm/fieldsets/ReceiveTokenField/MarketAssetSelect';
 import type { EmptyAddressPosition } from '@zeriontech/transactions';
 import { ReceiveFiatInputValue } from 'src/ui/components/FiatInputValue/FiatInputValue';
-import { calculatePriceImpact } from 'src/ui/pages/SwapForm/shared/price-impact';
+import type { PriceImpact } from 'src/ui/pages/SwapForm/shared/price-impact';
 
 export function ReceiveTokenField({
   receiveInput,
@@ -24,6 +24,7 @@ export function ReceiveTokenField({
   spendInput,
   spendAsset,
   onChangeToken,
+  priceImpact,
 }: {
   receiveInput?: string;
   receiveChain: Chain | null;
@@ -32,6 +33,7 @@ export function ReceiveTokenField({
   spendInput?: string;
   spendAsset: Asset | null;
   onChangeToken: (value: string) => void;
+  priceImpact: PriceImpact | null;
 }) {
   const positionBalanceCommon = receivePosition
     ? getPositionBalance(receivePosition)
@@ -49,17 +51,6 @@ export function ReceiveTokenField({
       tokenValueInputRef.current?.setValue('');
     }
   }, [receiveInput]);
-
-  const priceImpact = useMemo(
-    () =>
-      calculatePriceImpact({
-        inputValue: spendInput ?? null,
-        outputValue: receiveInput ?? null,
-        inputAsset: spendAsset,
-        outputAsset: receivePosition?.asset ?? null,
-      }),
-    [receivePosition?.asset, receiveInput, spendAsset, spendInput]
-  );
 
   const inputId = useId();
   const inputRef = useRef<HTMLInputElement | null>(null);

--- a/src/ui/pages/SwapForm/fieldsets/ReceiveTokenField/ReceiveTokenField.tsx
+++ b/src/ui/pages/SwapForm/fieldsets/ReceiveTokenField/ReceiveTokenField.tsx
@@ -27,6 +27,7 @@ export function ReceiveTokenField({
   onChange,
   outputAmount,
   priceImpact,
+  showPriceImpactWarning,
   readOnly = true,
 }: {
   formState: SwapFormState;
@@ -36,6 +37,7 @@ export function ReceiveTokenField({
   positions: AddressPosition[];
   outputAmount: string | null;
   priceImpact: PriceImpact | null;
+  showPriceImpactWarning: boolean;
   readOnly?: boolean;
 }) {
   const { inputAmount } = formState;
@@ -152,6 +154,7 @@ export function ReceiveTokenField({
             receiveInput={outputAmount ?? ''}
             receiveAsset={receivePosition?.asset ?? null}
             priceImpact={priceImpact}
+            showPriceImpactWarning={showPriceImpactWarning}
           />
         }
       />

--- a/src/ui/pages/SwapForm/shared/PriceImpactLine/PriceImpactLine.tsx
+++ b/src/ui/pages/SwapForm/shared/PriceImpactLine/PriceImpactLine.tsx
@@ -6,9 +6,6 @@ import { formatPercent } from 'src/shared/units/formatPercent';
 import { getPriceImpactPercentage, type PriceImpact } from '../price-impact';
 
 export function PriceImpactLine({ priceImpact }: { priceImpact: PriceImpact }) {
-  const isHighValueLoss =
-    priceImpact.kind === 'loss' && priceImpact.level === 'high';
-
   const priceImpactPercentage = priceImpact
     ? getPriceImpactPercentage(priceImpact)
     : null;
@@ -21,7 +18,7 @@ export function PriceImpactLine({ priceImpact }: { priceImpact: PriceImpact }) {
     [priceImpactPercentage]
   );
 
-  return isHighValueLoss ? (
+  return (
     <Surface padding={12} style={{ backgroundColor: 'var(--neutral-100)' }}>
       <HStack gap={4} justifyContent="space-between">
         <UIText kind="body/accent">High Price Impact</UIText>
@@ -32,5 +29,5 @@ export function PriceImpactLine({ priceImpact }: { priceImpact: PriceImpact }) {
         ) : null}
       </HStack>
     </Surface>
-  ) : null;
+  );
 }


### PR DESCRIPTION
In this pull requests there are few additions:
- Use data from quote to set protocol_fee, network_fee and gas_price params in the sign_transaction event
- Add warning_was_shown and output_text_color params to reflect price impact warning state
- Add price impact warning callout and extract all logic for detect what price impact warnings should we show to the top level of the form so the same calculation results are passed to analytics.