### PR TITLE
Filled form event

### DIFF
--- a/src/background/Wallet/Wallet.ts
+++ b/src/background/Wallet/Wallet.ts
@@ -69,6 +69,7 @@ import { getWalletNameFlagsByOrigin } from 'src/shared/preferences-helpers';
 import type {
   MessageContextParams,
   TransactionContextParams,
+  TransactionFormedContext,
 } from 'src/shared/types/SignatureContextParams';
 import { normalizeChainId } from 'src/shared/normalizeChainId';
 import { Networks } from 'src/modules/networks/Networks';
@@ -1722,6 +1723,14 @@ export class Wallet {
     // walletPort.request('sendEvent', { event_name, params }).
     this.verifyInternalOrigin(context);
     emitter.emit('screenView', params);
+  }
+
+  async transactionFormed({
+    context,
+    params,
+  }: WalletMethodParams<TransactionFormedContext>) {
+    this.verifyInternalOrigin(context);
+    emitter.emit('transactionFormed', params);
   }
 
   async daylightAction({

--- a/src/background/events.ts
+++ b/src/background/events.ts
@@ -4,6 +4,7 @@ import type { Chain } from 'src/modules/networks/Chain';
 import type {
   MessageContextParams,
   TransactionContextParams,
+  TransactionFormedContext,
 } from 'src/shared/types/SignatureContextParams';
 import type { AddEthereumChainParameter } from 'src/modules/ethereum/types/AddEthereumChainParameter';
 import type { ChainId } from 'src/modules/ethereum/transactions/ChainId';
@@ -40,6 +41,7 @@ export const emitter = createNanoEvents<{
     message: string;
   }) => void;
   switchChainError: (chainId: ChainId, origin: string, error: unknown) => void;
+  transactionFormed: (context: TransactionFormedContext) => void;
   transactionSent: (
     result: SignTransactionResult,
     context: { mode: 'default' | 'testnet' } & TransactionContextParams

--- a/src/shared/analytics/analytics.ts
+++ b/src/shared/analytics/analytics.ts
@@ -9,6 +9,7 @@ type MetabaseEvent =
   | 'dapp_connection'
   | 'signed_message'
   | 'signed_transaction'
+  | 'swap_form_filled_out'
   | 'client_error'
   | 'daylight_action'
   | 'custom_evm_network_created'

--- a/src/shared/analytics/shared/addressActionToAnalytics.ts
+++ b/src/shared/analytics/shared/addressActionToAnalytics.ts
@@ -75,7 +75,7 @@ function getAssetAddress({ asset }: { asset: ActionAsset }) {
   return getFungibleAsset(asset)?.asset_code;
 }
 
-function toMaybeArr<T>(
+export function toMaybeArr<T>(
   arr: (T | null | undefined)[] | null | undefined
 ): T[] | undefined {
   return arr?.length ? arr.filter(isTruthy) : undefined;

--- a/src/shared/types/SignatureContextParams.ts
+++ b/src/shared/types/SignatureContextParams.ts
@@ -1,4 +1,6 @@
 import type { AnyAddressAction } from 'src/modules/ethereum/transactions/addressAction';
+import type { SwapFormState } from 'src/ui/pages/SwapForm/shared/SwapFormState';
+import type { BridgeFormState } from 'src/ui/pages/BridgeForm/types';
 import type { Quote2 } from './Quote';
 
 type ClientScope =
@@ -41,3 +43,13 @@ export interface MessageContextParams {
   initiator: string;
   clientScope: ClientScope | null;
 }
+
+export type TransactionFormedContext = {
+  scope: 'Swap' | 'Bridge';
+  formState: SwapFormState | BridgeFormState;
+  slippagePercent?: number;
+  quote: Quote2;
+  enoughBalance: boolean;
+  warningWasShown: boolean;
+  outputAmountColor: 'red' | 'grey';
+};


### PR DESCRIPTION
This pull request is based on another one https://github.com/zeriontech/zerion-wallet-extension/pull/829
Cause all changes are about the same event. Please, take a look into the previous one first


New event should be sent when there is a new ready quote in the Swap/Bridge form.