### PR TITLE
Fix chart render

### DIFF
--- a/src/ui/components/chart/Chart.tsx
+++ b/src/ui/components/chart/Chart.tsx
@@ -200,6 +200,7 @@ export function Chart<T>({
       return;
     }
 
+    chartPointsRef.current = [];
     chartRef.current = new ChartJS(ctx, {
       ...DEFAULT_CONFIG,
       data: {
@@ -286,15 +287,17 @@ export function Chart<T>({
     };
   }, [onRangeSelectEvent, datasetConfig, plugins, tooltip, interaction]);
 
-  if (!equal(chartPointsRef.current, chartPoints) && chartRef.current) {
-    updateChartPoints({
-      chart: chartRef.current,
-      prevPoints: chartPointsRef.current,
-      nextPoints: chartPoints,
-      theme,
-    });
-    chartPointsRef.current = chartPoints;
-  }
+  useEffect(() => {
+    if (!equal(chartPointsRef.current, chartPoints) && chartRef.current) {
+      updateChartPoints({
+        chart: chartRef.current,
+        prevPoints: chartPointsRef.current,
+        nextPoints: chartPoints,
+        theme: themeRef.current,
+      });
+      chartPointsRef.current = chartPoints;
+    }
+  }, [chartPoints]);
 
   return (
     <div style={{ position: 'relative', height: CHART_HEIGHT, ...style }}>


### PR DESCRIPTION
This pr has a fix for Chart rendering when go back and forward in the Asset Page.
The problem was that on the second+ visit of the page, `chartPointsRef` still had old value + there are less renders and `updateChartPoints` wasn't called to provide points to the chart again.

A fix has 2 parts:
- move `updateChartPoints` into useEffect to provide correct call queue (create chart -> update points) on each page visit
- reset chartPointsRef when Chart is created. Chart is created with empty data, so chartPointsRef = [] is correct in this case