### PR TITLE
Fix approve state detection

### DIFF
--- a/src/ui/pages/BridgeForm/BridgeForm.tsx
+++ b/src/ui/pages/BridgeForm/BridgeForm.tsx
@@ -1396,10 +1396,10 @@ function BridgeFormComponent() {
                   }
                   holdToSign={false}
                 >
-                  {quotesData.isLoading
-                    ? 'Fetching offers'
-                    : approveMutation.isLoading || approveTxStatus === 'pending'
+                  {approveMutation.isLoading || approveTxStatus === 'pending'
                     ? 'Approving...'
+                    : quotesData.isLoading
+                    ? 'Fetching offers'
                     : `Approve ${inputPosition?.asset.symbol ?? null}`}
                 </SignTransactionButton>
               ) : null}

--- a/src/ui/pages/SwapForm/SwapForm.tsx
+++ b/src/ui/pages/SwapForm/SwapForm.tsx
@@ -1209,10 +1209,10 @@ function SwapFormComponent() {
                   }
                   holdToSign={false}
                 >
-                  {quotesData.isLoading
-                    ? 'Fetching offers'
-                    : approveMutation.isLoading || approveTxStatus === 'pending'
+                  {approveMutation.isLoading || approveTxStatus === 'pending'
                     ? 'Approving...'
+                    : quotesData.isLoading
+                    ? 'Fetching offers'
                     : `Approve ${inputPosition?.asset.symbol ?? null}`}
                 </SignTransactionButton>
               ) : null}


### PR DESCRIPTION
There was a broken state when approval tx is confirmed and we are fetching new quotes, the submit button had 'Approve' title.
This happened because we kept the previous "approval" quote while fetching new one.
So I added a check that there is no quote loading at the moment to show 'Approve' title.