### PR TITLE
ci: use GitHub App token for QA repo push

### DIFF
--- a/.github/actions/push_qa_repo/action.yml
+++ b/.github/actions/push_qa_repo/action.yml
@@ -1,22 +1,22 @@
 name: 'Push build to QA repository'
 
 inputs:
-  branch_name: 
+  branch_name:
     description: 'Branch name to push to'
     required: true
-  commit_message: 
+  commit_message:
     description: 'Commit message for the push'
     required: true
-  pat_token:
-    description: "QA repository PAT token"
+  repo_token:
+    description: "Token with contents:write on zerion-wallet-extension-qa (GitHub App installation token)"
     required: true
-    
+
 runs:
   using: "composite"
   steps:
     - name: Create branch in another repository and copy files
       env:
-        REPO_TOKEN: ${{ inputs.pat_token }}
+        REPO_TOKEN: ${{ inputs.repo_token }}
         BRANCH_NAME: ${{ inputs.branch_name }}
         COMMIT_MESSAGE: ${{ inputs.commit_message }}
       run: |
@@ -27,7 +27,7 @@ runs:
         git config --global user.name "QA Bot"
 
         # Clone the target repository
-        git clone "https://${REPO_TOKEN}@${TARGET_REPO}" qa-repository
+        git clone "https://x-access-token:${REPO_TOKEN}@${TARGET_REPO}" qa-repository
         cd qa-repository
 
         # Create or switch to the new branch

--- a/.github/workflows/pr_push_qa.yml
+++ b/.github/workflows/pr_push_qa.yml
@@ -94,8 +94,8 @@ jobs:
         id: qa-repo-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ secrets.ZERION_DEPLOY_APP_ID }}
-          private-key: ${{ secrets.ZERION_DEPLOY_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.QA_REPO_APP_ID }}
+          private-key: ${{ secrets.QA_REPO_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: zerion-wallet-extension-qa
 

--- a/.github/workflows/pr_push_qa.yml
+++ b/.github/workflows/pr_push_qa.yml
@@ -90,10 +90,19 @@ jobs:
           GIT_BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         run: node ./scripts/update-dev-manifest.js
 
+      - name: Get QA repo token
+        id: qa-repo-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.ZERION_DEPLOY_APP_ID }}
+          private-key: ${{ secrets.ZERION_DEPLOY_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: zerion-wallet-extension-qa
+
       - name: Push Build to QA Repository
         if: ${{ success() }}
         uses: ./.github/actions/push_qa_repo
         with:
           branch_name: ${{ github.head_ref || github.ref_name }}
           commit_message: 'PR #${{ github.event.pull_request.number }} - COMMIT ${{ github.event.head_commit.message }}'
-          pat_token: ${{ secrets.QA_REPOSITORY_PAT }}
+          repo_token: ${{ steps.qa-repo-token.outputs.token }}

--- a/.github/workflows/release_push_qa.yml
+++ b/.github/workflows/release_push_qa.yml
@@ -45,8 +45,8 @@ jobs:
         id: qa-repo-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ secrets.ZERION_DEPLOY_APP_ID }}
-          private-key: ${{ secrets.ZERION_DEPLOY_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.QA_REPO_APP_ID }}
+          private-key: ${{ secrets.QA_REPO_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: zerion-wallet-extension-qa
 

--- a/.github/workflows/release_push_qa.yml
+++ b/.github/workflows/release_push_qa.yml
@@ -41,10 +41,19 @@ jobs:
           npm install
           npm run build:production
 
+      - name: Get QA repo token
+        id: qa-repo-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.ZERION_DEPLOY_APP_ID }}
+          private-key: ${{ secrets.ZERION_DEPLOY_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: zerion-wallet-extension-qa
+
       - name: Push Build to QA Repository
         if: ${{ success() }}
         uses: ./.github/actions/push_qa_repo
         with:
           branch_name: 'release-${{ github.ref_name }}'
           commit_message: 'release-candidate-${{ github.ref_name }}'
-          pat_token: ${{ secrets.QA_REPOSITORY_PAT }}
+          repo_token: ${{ steps.qa-repo-token.outputs.token }}


### PR DESCRIPTION
- Replace the long-lived `QA_REPOSITORY_PAT` with a short-lived (~1h) installation token minted via `actions/create-github-app-token@v1`, scoped to `zerion-wallet-extension-qa` only.
- Composite action input renamed `pat_token` → `repo_token`; clone URL now uses the documented `https://x-access-token:<token>@github.com/...` form for App tokens.