### PR TITLE
add 15-day supply-chain cooldown for npm dependencies

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
 
       - name: Install dependencies and build
         env:
@@ -77,7 +77,7 @@ jobs:
           .github/scripts/set-env-from-pr-labels.sh "$PR_NUMBER"
           unset GH_TOKEN
           source $GITHUB_ENV
-          npm install
+          npm ci
           npm run build:production
 
       - name: Save PR number

--- a/.github/workflows/pr_push_qa.yml
+++ b/.github/workflows/pr_push_qa.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
 
         # Because of the logic about changing the icon during the active/disabled icon setup, we can't only change the icon in the manifest
         # So the alternative way to do this is to replace the files with the icon in the workflow
@@ -81,7 +81,7 @@ jobs:
           FEATURE_BRIDGE_FORM: on
           FEATURE_SOLANA: on
         run: |
-          npm install
+          npm ci
           npm run build:production
 
       - name: Update Dev Manifest file

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
 
       - name: Install dependencies and build
         env:
@@ -38,7 +38,7 @@ jobs:
           FEATURE_BRIDGE_FORM: on
           FEATURE_SOLANA: on
         run: |
-          npm install
+          npm ci
           npm run build:production
 
       - name: Compress build artifacts

--- a/.github/workflows/release_push_qa.yml
+++ b/.github/workflows/release_push_qa.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
 
       - name: Install dependencies and build
         env:
@@ -38,7 +38,7 @@ jobs:
           FEATURE_BRIDGE_FORM: on
           FEATURE_SOLANA: on
         run: |
-          npm install
+          npm ci
           npm run build:production
 
       - name: Get QA repo token

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
 
       - name: Install dependencies and build
         # TODO: Reuse env vars from ./pr.yml somehow
@@ -54,7 +54,7 @@ jobs:
           FEATURE_BRIDGE_FORM: on
           FEATURE_SOLANA: on
         run: |
-          npm install
+          npm ci
           npm run build:production
 
       - name: Run unit tests

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,7 @@
+# Reject package versions published less than 15 days ago (rolling supply-chain
+# cooldown). Requires npm >= 11.10.0
+#
+# To pull in an urgent fix newer than the window, override for a single run:
+#   npm install <pkg> --min-release-age=0
+# then commit the updated package-lock.json. See README for the policy.
+min-release-age=15

--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ You can also download the latest build of the Zerion Extension from [here](https
 
 ### 1. Set Up Node
 
-This project requires Node.js version >=16. If you don't have Node.js installed, download and install it from the [official website](https://nodejs.org/). After installation, you can verify the Node version using the following command:
+This project requires Node.js version >=20.10 and npm >=11.10. If you don't have Node.js installed, download and install it from the [official website](https://nodejs.org/). After installation, you can verify the versions using the following commands:
 
 ```shell
 node --version
+npm --version
 ```
 
 ### 2. Install Project Dependencies
@@ -37,6 +38,22 @@ Run the following command to install all the required dependencies. This command
 ```shell
 npm install
 ```
+
+### Supply-chain cooldown
+
+To reduce exposure to npm supply-chain attacks, this project enforces a **15-day cooldown**: `npm install` will only resolve dependency versions that were published more than 15 days ago. Compromised "fresh" releases are usually detected and unpublished within that window.
+
+This is configured via `min-release-age=15` in the project's `.npmrc` and requires **npm >=11.10** (older npm silently ignores it). It applies to every `npm install` here and in CI.
+
+The cooldown only affects version _resolution_ (i.e. updating `package-lock.json`); a plain install from an existing lockfile is unaffected.
+
+**Overriding for an urgent fix.** If you need a security patch newer than 15 days, bypass the window for a single install and commit the result:
+
+```shell
+npm install <package>@<version> --min-release-age=0
+```
+
+Then commit the updated `package-lock.json` with a note explaining why.
 
 ### 3. Set Up Your .env File
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,18 @@
   "engines": {
     "node": ">=20.10.0"
   },
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": ">=20.10.0",
+      "onFail": "error"
+    },
+    "packageManager": {
+      "name": "npm",
+      "version": ">=11.10.0",
+      "onFail": "error"
+    }
+  },
   "devDependencies": {
     "@eslint/js": "^9.29.0",
     "@parcel/config-webextension": "^2.14.4",


### PR DESCRIPTION
Enforce a rolling cooldown so npm only resolves dependency versions published more than 15 days ago, reducing exposure to compromised "fresh" releases. Malicious packages are typically detected and unpublished within that window.

- .npmrc: set min-release-age=15 (requires npm >= 11.10.0)
- package.json: add devEngines pinning node >=20.10 and npm >=11.10 with onFail: error, so an unsupported npm — which silently ignores min-release-age — hard-fails instead of skipping the cooldown
- workflows: bump CI to Node 24.x (Node 20 ships npm 10, which lacks min-release-age) and switch npm install -> npm ci for deterministic, lockfile-pinned installs
- README: document the policy and the --min-release-age=0 override for urgent security fixes

The cooldown only affects version resolution (updating package-lock.json); installs from the existing lockfile are unaffected.