### PR TITLE
WLT-1354: Truncate long NFT names in transaction preview

### DIFF
--- a/src/ui/components/address-action/ActInfo/ActInfo.tsx
+++ b/src/ui/components/address-action/ActInfo/ActInfo.tsx
@@ -88,7 +88,11 @@ function AssetContent({
         />
         <VStack gap={0}>
           <UIText kind="headline/h3">
-            <HStack gap={4} alignItems="center">
+            <HStack
+              gap={4}
+              alignItems="center"
+              style={{ gridTemplateColumns: 'auto 1fr' }}
+            >
               <span>
                 {amount?.quantity
                   ? `${


### PR DESCRIPTION
## Summary

The NFT branch of `ActInfo`'s `AssetContent` rendered its inner `HStack` without overriding the default `gridAutoColumns: 'minmax(min-content, max-content)'`. NFTs whose `metadata.name` falls back to a long unbreakable string (large numeric token ID) forced the column to grow past the container and visually overlap the Receive amount.

The fungible branch already sets `gridTemplateColumns: 'auto 1fr'` for exactly this reason. Apply the same override to the NFT branch so `NFTAnchor`'s existing `overflow: hidden` / `text-overflow: ellipsis` / `white-space: nowrap` actually take effect.

Closes WLT-1354

## Test plan

- [ ] Open a transaction preview containing an incoming NFT whose name resolves to a long numeric token ID (e.g. the Liquity Trade example in the issue) in the extension
- [ ] Confirm the NFT name truncates with an ellipsis inside the `Receive` row and no longer overlaps the amount column or container edge
- [ ] Confirm fungible transfer rows (with `+`/`-` amount and asset symbol) are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)