### PR TITLE
WLT-1270: queue port messages received during background init

### DIFF
--- a/src/background/messaging/PortRegistry.ts
+++ b/src/background/messaging/PortRegistry.ts
@@ -9,6 +9,13 @@ export type PortMessageHandler = (
 export class PortRegistry {
   private ports: RuntimePort[];
   private handlers: PortMessageHandler[];
+  // Messages that arrive before any handler is registered are buffered here.
+  // Without this, requests sent by content scripts while the background
+  // service worker is still running `initialize()` (handlers are pushed in
+  // its `.then` callback) hit an empty handler array and are silently
+  // dropped, leaving the dapp to wait until its own RPC timeout fires.
+  private queued: Array<[RuntimePort, unknown]>;
+  private drainScheduled: boolean;
   listener: (msg: unknown, port: RuntimePort) => void;
   private listeners: {
     onDisconnect: Set<(port: RuntimePort) => void>;
@@ -17,8 +24,14 @@ export class PortRegistry {
   constructor() {
     this.ports = [];
     this.handlers = [];
+    this.queued = [];
+    this.drainScheduled = false;
 
     this.listener = (msg: unknown, port: RuntimePort) => {
+      if (this.handlers.length === 0) {
+        this.queued.push([port, msg]);
+        return;
+      }
       for (const handler of this.handlers) {
         const didHandle = handler(port, msg);
         if (didHandle) {
@@ -68,6 +81,24 @@ export class PortRegistry {
 
   addMessageHandler(handler: PortMessageHandler) {
     this.handlers.push(handler);
+    if (this.queued.length && !this.drainScheduled) {
+      this.drainScheduled = true;
+      // Defer to a microtask so that any sibling `addMessageHandler` calls
+      // running in the same synchronous block (e.g. the post-`initialize`
+      // setup in src/background/index.ts) finish registering before the
+      // queued messages are replayed against the listener chain.
+      queueMicrotask(() => {
+        this.drainScheduled = false;
+        const queued = this.queued;
+        this.queued = [];
+        for (const [port, msg] of queued) {
+          // Skip messages whose port has disconnected during init.
+          if (this.ports.includes(port)) {
+            this.listener(msg, port);
+          }
+        }
+      });
+    }
   }
 
   postMessage<T>({ portName, message }: { portName: string; message: T }) {


### PR DESCRIPTION
## Summary

When a dapp like Polymarket calls `eth_requestAccounts` while the wallet extension's service worker is cold-starting, the request was silently dropped — the dapp's own RPC timeout (~30s in wagmi) fired and showed "Request Cancelled", even though the connection often succeeded once the popup finally opened.

Root cause: `PortRegistry.listener` (registered synchronously) ran against an empty `handlers` array, because `portRegistry.addMessageHandler(...)` calls live inside `initialize().then(...)` in `background/index.ts`. Recovery depended on the content-script eventually receiving the `background-initialized` broadcast and re-running `port.initialize()` to resend `pendingRequests` on a fresh port — a race the dapp's timeout typically won.

Fix: buffer messages that arrive while `handlers` is empty and replay them on the next microtask after the first `addMessageHandler` call (so all post-`initialize` registrations land before drain). Queued entries whose port disconnected mid-init are dropped, so we don't open popups for dead tabs.

Closes WLT-1270

## Test plan

- [ ] Reproduce the original bug: open Polymarket, lock the wallet, wait for the service worker to sleep, then click "Connect". Without the fix, the popup appears only after ~30s and Polymarket shows "Request Cancelled". With the fix, the popup should open promptly and Polymarket should treat the eventual approval as a successful connection.
- [ ] Sanity-check that normal `eth_requestAccounts` flows still work when the service worker is already warm (no regressions when `handlers` is non-empty on first message).
- [ ] Verify that closing a dapp tab while the SW is initializing does NOT spawn an orphan request popup once init completes (the disconnect filter in the drain).