### PR TITLE
Update lock button label to "Lock NOW!"

### DIFF
--- a/src/ui/pages/Settings/Settings.tsx
+++ b/src/ui/pages/Settings/Settings.tsx
@@ -374,7 +374,7 @@ function SettingsMain() {
             <HStack gap={8} alignItems="center" justifyContent="center">
               <LockIcon style={{ color: 'var(--white)' }} />
               <UIText kind="body/accent" color="var(--white)">
-                {logout.isLoading ? 'Locking...' : 'Lock Wallet'}
+                {logout.isLoading ? 'Locking...' : 'Lock NOW!'}
               </UIText>
             </HStack>
           </Button>


### PR DESCRIPTION
## Summary
- Change the Settings page lock button label from "Lock Wallet" to "Lock NOW!".

## Test plan
- [ ] Open Settings, confirm the bottom button reads "Lock NOW!".
- [ ] Tap it and confirm the loading state still shows "Locking..." and the wallet locks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)