### PR TITLE
WLT-1371: prevent testnet balance from overflowing the network selector

### DIFF
--- a/src/ui/components/NetworkSelectDialog/NetworkSelectDialog.tsx
+++ b/src/ui/components/NetworkSelectDialog/NetworkSelectDialog.tsx
@@ -61,7 +61,15 @@ function NativeBalance({ address, chain }: { address: string; chain: Chain }) {
     return null;
   }
   const { valueCommon, position } = balance;
-  return <span>{formatTokenValue(valueCommon, position?.asset.symbol)}</span>;
+  // Native balances on testnets / RPC-only chains can be enormous (e.g. faucet
+  // funds), which would render as a very long string and overflow the selector
+  // row. Show large balances using compact notation, e.g. "1.2M TEMPO".
+  const notation = valueCommon.abs().gte(1e6) ? 'compact' : undefined;
+  return (
+    <span>
+      {formatTokenValue(valueCommon, position?.asset.symbol, { notation })}
+    </span>
+  );
 }
 
 function NetworkItem({
@@ -123,6 +131,11 @@ function NetworkItem({
           <UIText
             kind="small/regular"
             color={selected ? 'var(--primary)' : 'var(--neutral-500)'}
+            style={{
+              overflow: 'hidden',
+              whiteSpace: 'nowrap',
+              textOverflow: 'ellipsis',
+            }}
           >
             {address &&
             ecosystem &&


### PR DESCRIPTION
## Summary

The Tempo testnet balance was overflowing the network selector row (reported for `0x13988cef5721a77e9a873b9c988559abd698516a`).

Testnet / RPC-only chains fall back to the `NativeBalance` path in `NetworkSelectDialog`, which renders the raw native balance via `formatTokenValue`. Faucet-sized testnet balances produce a very long number that, joined to its symbol by a non-breaking space, becomes a single unbreakable token. The row is a `space-between` `HStack` (CSS grid with `gridAutoColumns: minmax(min-content, max-content)`), so that unbreakable string forced the balance column to its full width and pushed the row past its bounds.

### Changes
- **Root cause** — render large native balances with compact notation (e.g. `1.2M TEMPO`) when the value is ≥ 1e6. Smaller balances keep their existing full precision. This only affects the `NativeBalance` fallback (native token on chains without backend portfolio data — i.e. testnets / RPC-only chains); fiat values via `ChainValue` are unchanged.
- **Backstop** — add `overflow: hidden; white-space: nowrap; text-overflow: ellipsis` to the balance cell (the established `textOverflowStyle` idiom from `Positions.tsx`). `overflow: hidden` collapses the grid item's automatic min-size to 0, so even a worst-case string or unusually long symbol truncates with an ellipsis instead of expanding the row.

Closes WLT-1371

## Test plan
- [ ] Open the network selector for a wallet holding a large Tempo testnet balance and confirm the row no longer overflows; the balance shows compactly (e.g. `1.2M TEMPO`).
- [ ] Confirm normal-sized native balances on testnets still render with full precision.
- [ ] Confirm mainnet rows (fiat value via portfolio data) are unchanged.
- [ ] Confirm the "hide balances" state still renders the placeholder squares correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)