### PR TITLE
WLT-1535: support unified accounts in Hyperliquid portfolio balance

### DIFF
--- a/src/modules/hyperliquid/fetchHyperliquidBalance.ts
+++ b/src/modules/hyperliquid/fetchHyperliquidBalance.ts
@@ -1,10 +1,22 @@
 import { perpClearinghouseState } from './api/requests/perp-clearinghouse-state.client';
 import { perpDexs } from './api/requests/perp-dexs.client';
+import { spotClearinghouseState } from './api/requests/spot-clearinghouse-state.client';
+import { userAbstraction } from './api/requests/user-abstraction.client';
+import { computeEffectiveAccountValueUSD } from './computeEffectiveValues';
 
 export async function fetchHyperliquidBalance(
   address: string
 ): Promise<number | null> {
-  const dexes = await perpDexs();
+  // Fan out the independent queries: perp DEX list, spot balances, and
+  // user-abstraction mode. Spot + abstraction are needed to support
+  // unified-account users, whose perp `marginSummary.accountValue` is
+  // unreliable (often ~0) — the live equity sits in `spot.USDC.total`.
+  const [dexes, spotState, abstractionMode] = await Promise.all([
+    perpDexs(),
+    spotClearinghouseState({ address }),
+    userAbstraction({ address }),
+  ]);
+
   // Main perp DEX (no `dex` param) is always queried, even if perpDexs fails.
   const dexIdentifiers: (string | undefined)[] = [undefined];
   if (dexes) {
@@ -13,20 +25,20 @@ export async function fetchHyperliquidBalance(
     }
   }
 
-  const states = await Promise.all(
+  const perpStates = await Promise.all(
     dexIdentifiers.map((dexIdentifier) =>
       perpClearinghouseState({ address, dexIdentifier })
     )
   );
 
-  let total = 0;
-  let anyOk = false;
-  for (const state of states) {
-    if (!state) continue;
-    anyOk = true;
-    const value = Number(state.marginSummary.accountValue);
-    if (Number.isFinite(value)) total += value;
-  }
-  if (!anyOk) return null;
+  const anyPerpOk = perpStates.some((state) => state != null);
+  if (!anyPerpOk) return null;
+
+  const total = computeEffectiveAccountValueUSD({
+    perpStates,
+    spotBalances: spotState?.balances ?? null,
+    abstractionMode: abstractionMode ?? 'disabled',
+  });
+
   return total > 0 ? total : null;
 }


### PR DESCRIPTION
## Summary

- `fetchHyperliquidBalance` was summing `marginSummary.accountValue` across perp DEXes — which is ~0 for unified-account (and portfolio-margin) users, since their USDC lives in the spot account and Hyperliquid auto-collateralises perps from it.
- Reuse the existing `computeEffectiveAccountValueUSD` helper (already used by the Perps trade screen) so the same mode-aware math drives the wallet overview's portfolio total.
- For unified / portfolio-margin modes the helper reads from `spot.USDC.total`; otherwise it falls back to the legacy perp-account sum, so non-unified users see no change.

Closes WLT-1535

## Test plan

- [ ] Open Overview for a unified-account address (e.g. `evgeny.eth`) — wallet total now includes the Hyperliquid spot USDC equity instead of the ~0 perp `accountValue`.
- [ ] Open Overview for a non-unified Hyperliquid user — wallet total still includes the summed perp account value across DEXes (no behavior change).
- [ ] Open Overview for an address without any Hyperliquid presence — totals unchanged; query falls through with `null`.
- [ ] Open Overview for a Solana-only / watch-only address — Hyperliquid request is still gated to EVM addresses by `useWalletPortfolio`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)