### PR TITLE
WLT-1539: remove A/B test around auto slippage option

### DIFF
--- a/src/modules/statsig/statsig.client.ts
+++ b/src/modules/statsig/statsig.client.ts
@@ -5,7 +5,6 @@ import { getStatsigExperiment, getStatsigFeatureGate } from './shared';
 export const ONRAMP_EXPERIMENT_NAME = 'web-onramp_flow';
 export const APPROVE_AND_TRADE_EXPERIMENT =
   'extension-approve_and_trade_in_1_action';
-export const AUTOSLIPPAGE_EXPERIMENT = 'web_-_autoslippage_testing';
 
 export function useStatsigExperiment(
   name: string,
@@ -37,25 +36,6 @@ export function useStatsigExperiment(
 export function useApproveAndTradeInOneAction() {
   const { data } = useStatsigExperiment(APPROVE_AND_TRADE_EXPERIMENT);
   return data?.group_name === 'Group1';
-}
-
-/**
- * Autoslippage A/B experiment (`web_-_autoslippage_testing`).
- * - Test group sees the "Auto" slippage option and defaults to it.
- * - Control (and any unresolved/failed state) hides Auto and uses the static
- *   chain default.
- * The resolved `group` label is reported to analytics as `autoslippage_test_group`.
- */
-export function useAutoslippageExperiment() {
-  const { data, isLoading } = useStatsigExperiment(AUTOSLIPPAGE_EXPERIMENT);
-  // Fall back to "Control" until the experiment resolves, so we never grant
-  // Auto mode to a user before we know their group.
-  const group = data?.group_name ?? 'Control';
-  return {
-    group,
-    isTestGroup: group === 'Group1',
-    isLoading,
-  };
 }
 
 export function useStatsigFeatureGate(

--- a/src/shared/analytics/analytics.background.ts
+++ b/src/shared/analytics/analytics.background.ts
@@ -310,7 +310,6 @@ function trackAppEvents({ account }: { account: Account }) {
       outputChain,
       warningWasShown = false,
       outputAmountColor = 'grey',
-      autoslippageTestGroup,
       actionType,
     } = context;
 
@@ -350,7 +349,6 @@ function trackAppEvents({ account }: { account: Account }) {
       slippage: quote?.finalSlippage ?? null,
       // Value computed by the autoslippage engine; present only in Auto mode.
       autoslippage: quote?.autoSlippage ?? null,
-      autoslippage_test_group: autoslippageTestGroup ?? null,
       action_type: actionType ?? null,
       ...omitNullParams(addressActionAnalytics),
     });
@@ -508,7 +506,6 @@ function trackAppEvents({ account }: { account: Account }) {
       warningWasShown,
       outputAmountColor,
       scope,
-      autoslippageTestGroup,
     } = context;
 
     // We query fungible info for input and output assets
@@ -591,7 +588,6 @@ function trackAppEvents({ account }: { account: Account }) {
       slippage: quote.finalSlippage ?? undefined,
       // Value computed by the autoslippage engine; present only in Auto mode.
       autoslippage: quote.autoSlippage ?? undefined,
-      autoslippage_test_group: autoslippageTestGroup,
       contract_type: quote.contractMetadata.name,
 
       fdv_asset_sent: inputAsset.meta.fullyDilutedValuation ?? undefined,

--- a/src/shared/types/SignatureContextParams.ts
+++ b/src/shared/types/SignatureContextParams.ts
@@ -28,12 +28,6 @@ export type TransactionContextParams = {
    */
   actionType?: string;
   /**
-   * Autoslippage A/B experiment group label (e.g. `'Group1'` / `'Control'`),
-   * resolved in the UI and forwarded so the background "Signed Transaction"
-   * event can report `autoslippage_test_group`. Only set for swap flows.
-   */
-  autoslippageTestGroup?: string;
-  /**
    * Currenly only applies to Solana dapp requests
    * This indicates the method that the dapp called originally
    * and dictates the strategy for the SendTransaction View flow.
@@ -66,6 +60,4 @@ export type TransactionFormedContext = {
   enoughBalance: boolean;
   warningWasShown: boolean;
   outputAmountColor: 'red' | 'grey';
-  /** Autoslippage A/B experiment group label (e.g. `'Group1'` / `'Control'`). */
-  autoslippageTestGroup?: string;
 };

--- a/src/ui/pages/SwapForm2/QuoteDetails/QuoteDetails.tsx
+++ b/src/ui/pages/SwapForm2/QuoteDetails/QuoteDetails.tsx
@@ -117,23 +117,13 @@ function ZerionFeeLabel() {
 
 function getSlippageDisplay(
   formState: SwapFormState2,
-  quote: Quote2 | null,
-  isAutoslippageEnabled: boolean
+  quote: Quote2 | null
 ): string {
   const chain = createChain(formState.inputChain);
   if (formState.slippage != null && formState.slippage !== 'auto') {
     const { slippagePercent } = getSlippageOptions({
       chain,
       userSlippage: Number(formState.slippage),
-    });
-    return `${slippagePercent}%`;
-  }
-  // Control (or unresolved experiment): no Auto mode \u2014 an untouched slippage
-  // resolves to the static chain default.
-  if (!isAutoslippageEnabled) {
-    const { slippagePercent } = getSlippageOptions({
-      chain,
-      userSlippage: null,
     });
     return `${slippagePercent}%`;
   }
@@ -153,7 +143,6 @@ export function QuoteDetails({
   gasPrices,
   onConfigurationChange,
   onProviderChange,
-  isAutoslippageEnabled,
 }: {
   quote: Quote2 | null;
   quotesQuery: QuotesData<Quote2>;
@@ -164,8 +153,6 @@ export function QuoteDetails({
   gasPrices: ChainGasPrice | null;
   onConfigurationChange: (configuration: CustomConfiguration) => void;
   onProviderChange: (quoteId: string | null) => void;
-  /** Autoslippage Test group: show the "Auto" option and Auto-mode display. */
-  isAutoslippageEnabled: boolean;
 }) {
   const [isExpanded, setIsExpanded] = useState(false);
   const providerDialog = useDialog2();
@@ -214,8 +201,7 @@ export function QuoteDetails({
   const isVisible = quotesQuery.isLoading || quote != null;
 
   const isAutoSlippage =
-    isAutoslippageEnabled &&
-    (formState.slippage == null || formState.slippage === 'auto');
+    formState.slippage == null || formState.slippage === 'auto';
   const showAutoSlippageInCollapsed =
     isAutoSlippage && quote?.finalSlippage != null && quote.finalSlippage > 1;
 
@@ -255,11 +241,7 @@ export function QuoteDetails({
                     value={
                       <HStack gap={4} alignItems="center">
                         <UIText kind="small/accent">
-                          {getSlippageDisplay(
-                            formState,
-                            quote,
-                            isAutoslippageEnabled
-                          )}
+                          {getSlippageDisplay(formState, quote)}
                         </UIText>
                         <ChevronRightIcon
                           className={styles.detailLinkChevron}
@@ -297,11 +279,7 @@ export function QuoteDetails({
                             value={
                               <HStack gap={4} alignItems="center">
                                 <UIText kind="small/accent">
-                                  {getSlippageDisplay(
-                                    formState,
-                                    quote,
-                                    isAutoslippageEnabled
-                                  )}
+                                  {getSlippageDisplay(formState, quote)}
                                 </UIText>
                                 <ChevronRightIcon
                                   className={styles.detailLinkChevron}
@@ -525,7 +503,7 @@ export function QuoteDetails({
         <div style={{ padding: 16, paddingTop: 0 }}>
           <SlippageSettings
             chain={inputChain}
-            includeAuto={isAutoslippageEnabled}
+            includeAuto={true}
             configuration={configuration}
             onConfigurationChange={(value) => {
               onConfigurationChange(value);

--- a/src/ui/pages/SwapForm2/SwapForm2.tsx
+++ b/src/ui/pages/SwapForm2/SwapForm2.tsx
@@ -39,7 +39,6 @@ import {
 } from 'src/ui/features/preferences/usePreferences';
 import { devMenuStore } from 'src/ui/features/dev-menu/store';
 import { walletPort } from 'src/ui/shared/channels';
-import { useAutoslippageExperiment } from 'src/modules/statsig/statsig.client';
 import { useEvent } from 'src/ui/shared/useEvent';
 import { useAddressParams } from 'src/ui/shared/user-address/useAddressParams';
 import { useNetworks } from 'src/modules/networks/useNetworks';
@@ -158,12 +157,6 @@ function SwapFormComponent({
     networks,
   });
 
-  // Autoslippage A/B experiment: Test group offers Auto mode (the default when
-  // slippage is untouched); Control (and any unresolved/failed state) hides Auto
-  // and falls back to the static chain default. `group` is reported to analytics.
-  const { group: autoslippageTestGroup, isTestGroup: isAutoslippageEnabled } =
-    useAutoslippageExperiment();
-
   const inputNetworkConfig = useMemo(
     () =>
       formState.inputChain
@@ -209,7 +202,6 @@ function SwapFormComponent({
       outputPosition,
       isCrossEcosystem,
       outputEcosystem,
-      isAutoslippageEnabled,
     });
 
   // Single shared gas-prices fetch for the input chain. Powers the local fee
@@ -292,7 +284,6 @@ function SwapFormComponent({
       formState,
       quote,
       scope: isCrossChain ? 'Bridge' : 'Swap',
-      autoslippageTestGroup,
       warningWasShown: Boolean(showPriceImpactCallout),
       outputAmountColor: showPriceImpactWarning ? 'red' : 'grey',
       enoughBalance:
@@ -557,7 +548,6 @@ function SwapFormComponent({
           addressAction: interpretationAction ?? fallbackSwapAction,
           quote,
           outputChain: formState.outputChain,
-          autoslippageTestGroup,
           warningWasShown: Boolean(showPriceImpactCallout),
           outputAmountColor: showPriceImpactWarning ? 'red' : 'grey',
         },
@@ -796,7 +786,6 @@ function SwapFormComponent({
               setUserFormState((state) => ({ ...state, ...partial }));
             }}
             onProviderChange={setUserQuoteId}
-            isAutoslippageEnabled={isAutoslippageEnabled}
           />
           <TransactionWarning warning={resolved.warning} />
           {showPriceImpactCallout ? (

--- a/src/ui/pages/SwapForm2/useSwapQuote.ts
+++ b/src/ui/pages/SwapForm2/useSwapQuote.ts
@@ -5,8 +5,6 @@ import { useQuotesV2 } from 'src/ui/shared/requests/useQuotes';
 import type { FungiblePosition } from 'src/modules/zerion-api/requests/wallet-get-simple-positions';
 import type { BlockchainType } from 'src/shared/wallet/classifiers';
 import { resolveTokenValue } from 'src/ui/components/AmountInput/inputKind';
-import { createChain } from 'src/modules/networks/Chain';
-import { getSlippageOptions } from 'src/ui/pages/SwapForm/SlippageSettings/getSlippageOptions';
 import type { SwapFormState2 } from './types';
 import { isReceiverReadyForQuote } from './shared/getCrossEcosystemState';
 
@@ -17,7 +15,6 @@ export function useSwapQuote({
   outputPosition,
   isCrossEcosystem,
   outputEcosystem,
-  isAutoslippageEnabled,
 }: {
   address: string;
   formState: SwapFormState2;
@@ -25,12 +22,6 @@ export function useSwapQuote({
   outputPosition: FungiblePosition | null;
   isCrossEcosystem: boolean;
   outputEcosystem: BlockchainType | null;
-  /**
-   * Autoslippage A/B Test group. When `false` (Control / unresolved), an
-   * untouched slippage resolves to the static chain default instead of being
-   * omitted, so the backend never computes an auto slippage.
-   */
-  isAutoslippageEnabled: boolean;
 }) {
   const { currency } = useCurrency();
   const { pathname } = useLocation();
@@ -57,22 +48,8 @@ export function useSwapQuote({
       gasLimit: _gasLimit,
       ...rest
     } = formState;
-    // Autoslippage gating: in the Control group (or before the experiment
-    // resolves) an untouched slippage must resolve to the static chain default
-    // rather than being omitted — omitting it would let the backend compute an
-    // auto slippage, which is the Test-group behavior.
-    const slippageUntouched = rest.slippage == null || rest.slippage === 'auto';
-    const slippage =
-      !isAutoslippageEnabled && slippageUntouched && rest.inputChain
-        ? String(
-            getSlippageOptions({
-              chain: createChain(rest.inputChain),
-              userSlippage: null,
-            }).slippage
-          )
-        : rest.slippage;
-    return { ...rest, slippage, inputAmount: resolvedInputAmount };
-  }, [formState, resolvedInputAmount, isAutoslippageEnabled]);
+    return { ...rest, inputAmount: resolvedInputAmount };
+  }, [formState, resolvedInputAmount]);
 
   const inputFiatValue = useMemo(() => {
     if (!resolvedInputAmount || inputPrice == null) return null;


### PR DESCRIPTION
## Summary

- Drops the `web_-_autoslippage_testing` Statsig experiment and its hook (`useAutoslippageExperiment`); Auto slippage is now the default for everyone in `SwapForm2`.
- Removes the `isAutoslippageEnabled` plumbing through `SwapForm2` → `useSwapQuote` / `QuoteDetails` (incl. the slippage-untouched fallback that forced the static chain default for the Control group).
- Removes the `autoslippage_test_group` analytics field from `swap_form_filled_out` and `signed_transaction` events, and the matching `autoslippageTestGroup` field from `TransactionContextParams` / `TransactionFormedContext`.

Closes WLT-1539

## Test plan

- [ ] Open the Swap form (SwapForm2) and confirm "Auto" appears as the default slippage option, regardless of Statsig group.
- [ ] Pick a manual slippage value, swap, and confirm the chosen value is honored end-to-end.
- [ ] Confirm cross-chain (bridge) swaps still resolve a quote (no `slippage` request regressions).
- [ ] Verify `signed_transaction` / `swap_form_filled_out` analytics events no longer carry `autoslippage_test_group`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)