### PR TITLE
WLT-1541: add perps analytics events to extension

### DIFF
--- a/src/background/Wallet/Wallet.ts
+++ b/src/background/Wallet/Wallet.ts
@@ -92,6 +92,11 @@ import type {
   BannerClickedParams,
   ButtonClickedParams,
 } from 'src/shared/types/button-events';
+import type {
+  PerpsButtonPressedParams,
+  PerpsPositionActionParams,
+  PerpsScreenViewedParams,
+} from 'src/shared/types/perps-events';
 import { signTypedData } from 'src/modules/ethereum/message-signing/signTypedData';
 import type { SerializableTransactionResponse } from 'src/modules/ethereum/types/TransactionResponsePlain';
 import {
@@ -1828,6 +1833,30 @@ export class Wallet {
   }: WalletMethodParams<BannerClickedParams>) {
     this.verifyInternalOrigin(context);
     emitter.emit('bannerClicked', params);
+  }
+
+  async perpsScreenViewed({
+    context,
+    params,
+  }: WalletMethodParams<PerpsScreenViewedParams>) {
+    this.verifyInternalOrigin(context);
+    emitter.emit('perpsScreenViewed', params);
+  }
+
+  async perpsButtonPressed({
+    context,
+    params,
+  }: WalletMethodParams<PerpsButtonPressedParams>) {
+    this.verifyInternalOrigin(context);
+    emitter.emit('perpsButtonPressed', params);
+  }
+
+  async perpsPositionAction({
+    context,
+    params,
+  }: WalletMethodParams<PerpsPositionActionParams>) {
+    this.verifyInternalOrigin(context);
+    emitter.emit('perpsPositionAction', params);
   }
 
   async assetClicked({

--- a/src/background/events.ts
+++ b/src/background/events.ts
@@ -12,6 +12,11 @@ import type {
   BannerClickedParams,
   ButtonClickedParams,
 } from 'src/shared/types/button-events';
+import type {
+  PerpsButtonPressedParams,
+  PerpsPositionActionParams,
+  PerpsScreenViewedParams,
+} from 'src/shared/types/perps-events';
 import type { WindowType } from 'src/shared/types/UrlContext';
 import type { SignTransactionResult } from 'src/shared/types/SignTransactionResult';
 import type { QuoteErrorContext } from 'src/shared/types/QuoteErrorContext';
@@ -110,4 +115,7 @@ export const emitter = createNanoEvents<{
   mnemonicRestorationSuccess: () => void;
   mnemonicRestorationError: () => void; // we do not pass error body to analytics to avoid sensitive data leaks
   reportLedgerError: (errorMessage: string) => void;
+  perpsScreenViewed: (data: PerpsScreenViewedParams) => void;
+  perpsButtonPressed: (data: PerpsButtonPressedParams) => void;
+  perpsPositionAction: (data: PerpsPositionActionParams) => void;
 }>();

--- a/src/shared/analytics/analytics.background.ts
+++ b/src/shared/analytics/analytics.background.ts
@@ -237,6 +237,48 @@ function trackAppEvents({ account }: { account: Account }) {
     mixpanelTrack(event_name, mixpanelParams);
   });
 
+  emitter.on('perpsScreenViewed', async (data) => {
+    const preferences = await globalPreferences.getPreferences();
+    if (!preferences.analyticsEnabled) {
+      return;
+    }
+    const params = createParams({
+      request_name: 'perps_screen_viewed',
+      screen_name: data.screen_name,
+      asset_name: data.asset_name,
+    });
+    const mixpanelParams = omit(params, ['request_name', 'wallet_address']);
+    mixpanelTrack('Perps: Screen Viewed', mixpanelParams);
+  });
+
+  emitter.on('perpsButtonPressed', async (data) => {
+    const preferences = await globalPreferences.getPreferences();
+    if (!preferences.analyticsEnabled) {
+      return;
+    }
+    const params = createParams({
+      request_name: 'perps_button_pressed',
+      button_name: data.button_name,
+      screen_name: data.screen_name,
+    });
+    const mixpanelParams = omit(params, ['request_name', 'wallet_address']);
+    mixpanelTrack('Perps: Button Pressed', mixpanelParams);
+  });
+
+  emitter.on('perpsPositionAction', async (data) => {
+    const preferences = await globalPreferences.getPreferences();
+    if (!preferences.analyticsEnabled) {
+      return;
+    }
+    const params = createParams({
+      request_name: 'perps_position_action',
+      ...data,
+    });
+    sendToMetabase('perps_position_action', params);
+    const mixpanelParams = omit(params, ['request_name', 'wallet_address']);
+    mixpanelTrack('Perps: Position Action', mixpanelParams);
+  });
+
   emitter.on('assetClicked', async (data) => {
     const preferences = await globalPreferences.getPreferences();
     if (!preferences.analyticsEnabled) {

--- a/src/shared/analytics/analytics.client.ts
+++ b/src/shared/analytics/analytics.client.ts
@@ -97,6 +97,18 @@ function trackAppEvents({
     walletPort.request('bannerClicked', data);
   });
 
+  emitter.on('perpsScreenViewed', async (data) => {
+    walletPort.request('perpsScreenViewed', data);
+  });
+
+  emitter.on('perpsButtonPressed', async (data) => {
+    walletPort.request('perpsButtonPressed', data);
+  });
+
+  emitter.on('perpsPositionAction', async (data) => {
+    walletPort.request('perpsPositionAction', data);
+  });
+
   emitter.on('errorScreenView', async (data) => {
     const preferences = await fetchGlobalPreferences();
     if (!preferences.analyticsEnabled) {

--- a/src/shared/analytics/analytics.ts
+++ b/src/shared/analytics/analytics.ts
@@ -34,7 +34,10 @@ type MetabaseEvent =
   | 'mnemonic_restoration_shown'
   | 'mnemonic_restoration_success'
   | 'mnemonic_restoration_error'
-  | 'report_ledger_error';
+  | 'report_ledger_error'
+  | 'perps_screen_viewed'
+  | 'perps_button_pressed'
+  | 'perps_position_action';
 
 type BaseParams<E = MetabaseEvent> = { request_name: E };
 

--- a/src/shared/types/perps-events.ts
+++ b/src/shared/types/perps-events.ts
@@ -1,0 +1,73 @@
+// Shared event types for perps analytics. Mirrors the web app's
+// `PerpsPositionActionParams` / `PERPS_SCREEN` / `PERPS_BUTTON` so the same
+// Mixpanel / Metabase events emit the same shape from both apps.
+
+export const PERPS_SCREEN = {
+  Asset: 'Asset',
+  Overview: 'Overview',
+  Deposit: 'Deposit',
+  Withdraw: 'Withdraw',
+  Long: 'Long',
+  Short: 'Short',
+  AddToLong: 'Add to Long',
+  AddToShort: 'Add to Short',
+  CloseLong: 'Close Long',
+  CloseShort: 'Close Short',
+  AdjustLeverage: 'Adjust Leverage',
+  TakeProfitStopLoss: 'Take Profit / Stop Loss',
+} as const;
+
+export const PERPS_BUTTON = {
+  Deposit: 'Deposit',
+  Withdraw: 'Withdraw',
+  Long: 'Long',
+  Short: 'Short',
+  Add: 'Add',
+  Close: 'Close',
+  AdjustLeverage: 'Adjust Leverage',
+  TakeProfitStopLoss: 'Take Profit / Stop Loss',
+} as const;
+
+export interface PerpsScreenViewedParams {
+  screen_name: string;
+  asset_name?: string;
+}
+
+export interface PerpsButtonPressedParams {
+  button_name: string;
+  screen_name: string;
+}
+
+export interface PerpsPositionActionParams {
+  position_side: 'Long' | 'Short';
+  action_type: 'Open' | 'Add' | 'Close';
+  asset_name: string;
+  leverage: number;
+  zerion_fee_percentage: number;
+  zerion_fee_usd_amount: number;
+  provider_fee_percentage: number;
+  provider_fee_usd_amount: number;
+  entry_price_usd: number;
+  size: number;
+  margin: number;
+  delta_size: number;
+  delta_margin: number;
+  screen_name: string;
+  success_status: boolean;
+  amount_usd?: number;
+  liquidation_price_usd?: number;
+  backend_error_message?: string;
+  take_profit_usd?: number;
+  stop_loss_usd?: number;
+  receive_usd_amount?: number;
+  realized_pnl_usd?: number;
+}
+
+/**
+ * Built by the trade forms at submit time. The submission flow adds the
+ * outcome (`success_status` / `backend_error_message`) once the order settles.
+ */
+export type PerpsPositionActionFormParams = Omit<
+  PerpsPositionActionParams,
+  'success_status' | 'backend_error_message'
+>;

--- a/src/ui/pages/Perps/PerpPage.tsx
+++ b/src/ui/pages/Perps/PerpPage.tsx
@@ -19,6 +19,8 @@ import { PageTop } from 'src/ui/components/PageTop';
 import { PageBottom } from 'src/ui/components/PageBottom';
 import { walletPort } from 'src/ui/shared/channels';
 import { useAddressParams } from 'src/ui/shared/user-address/useAddressParams';
+import { PERPS_BUTTON, PERPS_SCREEN } from 'src/shared/types/perps-events';
+import { emitter } from 'src/ui/shared/events';
 import { Button } from 'src/ui/ui-kit/Button';
 import { HStack } from 'src/ui/ui-kit/HStack';
 import { Spacer } from 'src/ui/ui-kit/Spacer';
@@ -183,6 +185,12 @@ export function PerpPage() {
                 size={48}
                 as={UnstyledLink}
                 to={`${tradePath}?mode=add`}
+                onClick={() => {
+                  emitter.emit('perpsButtonPressed', {
+                    button_name: PERPS_BUTTON.Add,
+                    screen_name: PERPS_SCREEN.Asset,
+                  });
+                }}
               >
                 <UIText kind="body/accent">Add</UIText>
               </Button>
@@ -191,6 +199,12 @@ export function PerpPage() {
                 size={48}
                 as={UnstyledLink}
                 to={`${tradePath}?mode=close`}
+                onClick={() => {
+                  emitter.emit('perpsButtonPressed', {
+                    button_name: PERPS_BUTTON.Close,
+                    screen_name: PERPS_SCREEN.Asset,
+                  });
+                }}
               >
                 <UIText kind="body/accent">Close</UIText>
               </Button>
@@ -208,6 +222,12 @@ export function PerpPage() {
                 size={48}
                 as={UnstyledLink}
                 to={`${tradePath}?mode=open&side=long`}
+                onClick={() => {
+                  emitter.emit('perpsButtonPressed', {
+                    button_name: PERPS_BUTTON.Long,
+                    screen_name: PERPS_SCREEN.Asset,
+                  });
+                }}
               >
                 <UIText kind="body/accent">Long</UIText>
               </Button>
@@ -216,6 +236,12 @@ export function PerpPage() {
                 size={48}
                 as={UnstyledLink}
                 to={`${tradePath}?mode=open&side=short`}
+                onClick={() => {
+                  emitter.emit('perpsButtonPressed', {
+                    button_name: PERPS_BUTTON.Short,
+                    screen_name: PERPS_SCREEN.Asset,
+                  });
+                }}
               >
                 <UIText kind="body/accent">Short</UIText>
               </Button>

--- a/src/ui/pages/Perps/PerpsDeposit/PerpsDeposit.tsx
+++ b/src/ui/pages/Perps/PerpsDeposit/PerpsDeposit.tsx
@@ -54,6 +54,8 @@ import { ErrorMessage } from 'src/ui/shared/error-display/ErrorMessage';
 import { InputPosition } from 'src/ui/pages/SwapForm2/InputPosition';
 import type { SwapFormState2 } from 'src/ui/pages/SwapForm2/types';
 import { HoldableButton } from 'src/ui/pages/SwapForm2/SwapButton/HoldableButton';
+import { PERPS_SCREEN } from 'src/shared/types/perps-events';
+import { emitter } from 'src/ui/shared/events';
 import { PerpsOnboarding } from '../PerpsOnboarding';
 import { RiskDisclosureBlock } from '../Blocks/RiskDisclosureBlock';
 import { DepositFormSkeleton } from './DepositFormSkeleton';
@@ -531,6 +533,12 @@ function DepositFormBody({
 }
 
 function DepositPageInner({ address }: { address: string }) {
+  useEffect(() => {
+    emitter.emit('perpsScreenViewed', {
+      screen_name: PERPS_SCREEN.Deposit,
+    });
+  }, []);
+
   const { currency } = useCurrency();
   const refetchInterval = usePositionsRefetchInterval(20000);
   const { data, isLoading } = useWalletSimplePositions(

--- a/src/ui/pages/Perps/PerpsOverview/PerpsOverview.tsx
+++ b/src/ui/pages/Perps/PerpsOverview/PerpsOverview.tsx
@@ -22,6 +22,8 @@ import { UnstyledButton } from 'src/ui/ui-kit/UnstyledButton';
 import { UnstyledLink } from 'src/ui/ui-kit/UnstyledLink';
 import { useAddressParams } from 'src/ui/shared/user-address/useAddressParams';
 import { usePreferences } from 'src/ui/features/preferences/usePreferences';
+import { PERPS_BUTTON, PERPS_SCREEN } from 'src/shared/types/perps-events';
+import { emitter } from 'src/ui/shared/events';
 import { VStack } from 'src/ui/ui-kit/VStack';
 import skeletonStyles from 'src/ui/pages/SwapForm2/styles.module.css';
 import { PerpsOnboarding } from '../PerpsOnboarding';
@@ -119,6 +121,12 @@ function PerpsPositionsList({
               kind="primary"
               as={UnstyledLink}
               to="/perps/deposit"
+              onClick={() => {
+                emitter.emit('perpsButtonPressed', {
+                  button_name: PERPS_BUTTON.Deposit,
+                  screen_name: PERPS_SCREEN.Overview,
+                });
+              }}
             >
               Deposit
             </Button>
@@ -339,6 +347,12 @@ export function PerpsOverview() {
             title="Deposit"
             aria-label="Deposit"
             style={{ paddingInline: 8 }}
+            onClick={() => {
+              emitter.emit('perpsButtonPressed', {
+                button_name: PERPS_BUTTON.Deposit,
+                screen_name: PERPS_SCREEN.Overview,
+              });
+            }}
           >
             <UIText kind="small/accent">Deposit</UIText>
           </Button>
@@ -350,6 +364,12 @@ export function PerpsOverview() {
             title="Withdraw"
             aria-label="Withdraw"
             style={{ paddingInline: 8 }}
+            onClick={() => {
+              emitter.emit('perpsButtonPressed', {
+                button_name: PERPS_BUTTON.Withdraw,
+                screen_name: PERPS_SCREEN.Overview,
+              });
+            }}
           >
             <UIText kind="small/accent">Withdraw</UIText>
           </Button>

--- a/src/ui/pages/Perps/PerpsTrade/AddToPositionForm.tsx
+++ b/src/ui/pages/Perps/PerpsTrade/AddToPositionForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useCurrency } from 'src/modules/currency/useCurrency';
 import { formatCurrencyValue } from 'src/shared/units/formatCurrencyValue';
 import { formatPriceValue } from 'src/shared/units/formatPriceValue';
@@ -9,6 +9,8 @@ import { calculatePositionSize } from 'src/modules/hyperliquid/calc/calculatePos
 import { calculateIsolatedLiquidationPrice } from 'src/modules/hyperliquid/calc/calculateLiquidationPrice';
 import { MIN_ORDER_NOTIONAL_USD } from 'src/modules/hyperliquid/constants';
 import { getPerpDisplayName } from 'src/modules/hyperliquid/parsePerpId';
+import { PERPS_SCREEN } from 'src/shared/types/perps-events';
+import { emitter } from 'src/ui/shared/events';
 import { Frame } from 'src/ui/ui-kit/Frame';
 import { HStack } from 'src/ui/ui-kit/HStack';
 import { UIText } from 'src/ui/ui-kit/UIText';
@@ -52,6 +54,15 @@ export function AddToPositionForm({
   const { currency } = useCurrency();
   const positionSzi = Number(position.szi);
   const isLong = positionSzi >= 0;
+  const screenName = isLong ? PERPS_SCREEN.AddToLong : PERPS_SCREEN.AddToShort;
+  const assetName = asset.universe.name;
+  useEffect(() => {
+    emitter.emit('perpsScreenViewed', {
+      screen_name: screenName,
+      asset_name: assetName,
+    });
+  }, [screenName, assetName]);
+
   const positionAbsSize = Math.abs(positionSzi);
   const positionLeverage = position.leverage.value;
   const inputAmount = formState.inputAmount;

--- a/src/ui/pages/Perps/PerpsTrade/AutoCloseOverlay.tsx
+++ b/src/ui/pages/Perps/PerpsTrade/AutoCloseOverlay.tsx
@@ -1,4 +1,6 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
+import { PERPS_SCREEN } from 'src/shared/types/perps-events';
+import { emitter } from 'src/ui/shared/events';
 import { Button } from 'src/ui/ui-kit/Button';
 import {
   SegmentedControlGroup,
@@ -112,6 +114,12 @@ function AutoCloseDialogBody({
   onConfirm,
   onClose,
 }: DialogProps) {
+  useEffect(() => {
+    emitter.emit('perpsScreenViewed', {
+      screen_name: PERPS_SCREEN.TakeProfitStopLoss,
+    });
+  }, []);
+
   // The overlay always opens in PnL view, hydrated from the stored prices.
   const [mode, setMode] = useState<Mode>('pnl');
   const [tp, setTp] = useState(() =>

--- a/src/ui/pages/Perps/PerpsTrade/ClosePositionForm.tsx
+++ b/src/ui/pages/Perps/PerpsTrade/ClosePositionForm.tsx
@@ -1,10 +1,12 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useCurrency } from 'src/modules/currency/useCurrency';
 import { formatCurrencyValue } from 'src/shared/units/formatCurrencyValue';
 import { formatTokenValue } from 'src/shared/units/formatTokenValue';
 import type { PerpAssetEntry } from 'src/modules/hyperliquid/findPerpAsset';
 import type { PerpPosition } from 'src/modules/hyperliquid/api/requests/perp-clearinghouse-state.types';
 import { MIN_ORDER_NOTIONAL_USD } from 'src/modules/hyperliquid/constants';
+import { PERPS_SCREEN } from 'src/shared/types/perps-events';
+import { emitter } from 'src/ui/shared/events';
 import { Frame } from 'src/ui/ui-kit/Frame';
 import { HStack } from 'src/ui/ui-kit/HStack';
 import { UIText } from 'src/ui/ui-kit/UIText';
@@ -45,6 +47,18 @@ export function ClosePositionForm({
 }) {
   const { currency } = useCurrency();
   const positionSzi = Number(position.szi);
+  const isPositionLong = positionSzi >= 0;
+  const screenName = isPositionLong
+    ? PERPS_SCREEN.CloseLong
+    : PERPS_SCREEN.CloseShort;
+  const assetName = asset.universe.name;
+  useEffect(() => {
+    emitter.emit('perpsScreenViewed', {
+      screen_name: screenName,
+      asset_name: assetName,
+    });
+  }, [screenName, assetName]);
+
   const positionAbsSize = Math.abs(positionSzi);
   const positionValueAbs = Math.abs(Number(position.positionValue));
   const positionLeverage = position.leverage.value;

--- a/src/ui/pages/Perps/PerpsTrade/LeverageOverlay.tsx
+++ b/src/ui/pages/Perps/PerpsTrade/LeverageOverlay.tsx
@@ -1,4 +1,6 @@
 import React, { useState } from 'react';
+import { PERPS_SCREEN } from 'src/shared/types/perps-events';
+import { emitter } from 'src/ui/shared/events';
 import { Button } from 'src/ui/ui-kit/Button';
 import { HStack } from 'src/ui/ui-kit/HStack';
 import { UIText } from 'src/ui/ui-kit/UIText';
@@ -32,6 +34,14 @@ export function LeverageOverlay({
   React.useEffect(() => {
     if (open) setValue(clamp(initialLeverage, 1, maxLeverage));
   }, [open, initialLeverage, maxLeverage]);
+
+  React.useEffect(() => {
+    if (open) {
+      emitter.emit('perpsScreenViewed', {
+        screen_name: PERPS_SCREEN.AdjustLeverage,
+      });
+    }
+  }, [open]);
 
   const chips = Array.from(
     new Set([...PRESETS.filter((p) => p <= maxLeverage), maxLeverage])

--- a/src/ui/pages/Perps/PerpsTrade/OpenPositionForm.tsx
+++ b/src/ui/pages/Perps/PerpsTrade/OpenPositionForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PlusIcon from 'jsx:src/ui/assets/plus.svg';
 import { useCurrency } from 'src/modules/currency/useCurrency';
 import { formatCurrencyValue } from 'src/shared/units/formatCurrencyValue';
@@ -7,6 +7,8 @@ import type { PerpAssetEntry } from 'src/modules/hyperliquid/findPerpAsset';
 import { calculatePositionSize } from 'src/modules/hyperliquid/calc/calculatePositionSize';
 import { calculateIsolatedLiquidationPrice } from 'src/modules/hyperliquid/calc/calculateLiquidationPrice';
 import { MIN_ORDER_NOTIONAL_USD } from 'src/modules/hyperliquid/constants';
+import { PERPS_BUTTON, PERPS_SCREEN } from 'src/shared/types/perps-events';
+import { emitter } from 'src/ui/shared/events';
 import { Frame } from 'src/ui/ui-kit/Frame';
 import { HStack } from 'src/ui/ui-kit/HStack';
 import { UIText } from 'src/ui/ui-kit/UIText';
@@ -57,6 +59,15 @@ export function OpenPositionForm({
 }) {
   const { currency } = useCurrency();
   const side: TradeSide = formState.side ?? 'long';
+  const screenName = side === 'long' ? PERPS_SCREEN.Long : PERPS_SCREEN.Short;
+  const assetName = asset.universe.name;
+  useEffect(() => {
+    emitter.emit('perpsScreenViewed', {
+      screen_name: screenName,
+      asset_name: assetName,
+    });
+  }, [screenName, assetName]);
+
   const leverage = formState.leverage ?? 1;
   const inputAmount = formState.inputAmount;
   const marginUsd = Number(inputAmount) || 0;
@@ -160,7 +171,13 @@ export function OpenPositionForm({
           <UnstyledButton
             type="button"
             className={s.controlGroupRow}
-            onClick={onOpenLeverage}
+            onClick={() => {
+              emitter.emit('perpsButtonPressed', {
+                button_name: PERPS_BUTTON.AdjustLeverage,
+                screen_name: screenName,
+              });
+              onOpenLeverage();
+            }}
           >
             <VStack gap={0} className={s.controlGroupRowLeft}>
               <UIText kind="small/accent">Leverage</UIText>
@@ -181,7 +198,13 @@ export function OpenPositionForm({
           <UnstyledButton
             type="button"
             className={s.controlGroupRow}
-            onClick={onOpenAutoClose}
+            onClick={() => {
+              emitter.emit('perpsButtonPressed', {
+                button_name: PERPS_BUTTON.TakeProfitStopLoss,
+                screen_name: screenName,
+              });
+              onOpenAutoClose();
+            }}
           >
             <VStack gap={2} className={s.controlGroupRowLeft}>
               <UIText kind="small/accent">Take Profit / Stop Loss</UIText>

--- a/src/ui/pages/Perps/PerpsTrade/PerpsTrade.tsx
+++ b/src/ui/pages/Perps/PerpsTrade/PerpsTrade.tsx
@@ -16,6 +16,7 @@ import {
   markHyperliquidOpSubmitted,
   useHyperliquidRefetchInterval,
 } from 'src/modules/hyperliquid/useHyperliquidRefetchInterval';
+import { calculateIsolatedLiquidationPrice } from 'src/modules/hyperliquid/calc/calculateLiquidationPrice';
 import { calculatePositionSize } from 'src/modules/hyperliquid/calc/calculatePositionSize';
 import { calculatePriceWithSlippage } from 'src/modules/hyperliquid/calc/calculatePriceWithSlippage';
 import { computeAssetId } from 'src/modules/hyperliquid/calc/computeAssetId';
@@ -31,6 +32,13 @@ import {
 import type { ExchangePlaceOrderPayload } from 'src/modules/hyperliquid/actions/types';
 import { MIN_ORDER_NOTIONAL_USD } from 'src/modules/hyperliquid/constants';
 import { runPerpsIntent } from 'src/modules/hyperliquid/useCases';
+import type { PerpsIntent } from 'src/modules/hyperliquid/useCases/runIntent';
+import { getError } from 'src/shared/errors/getError';
+import {
+  PERPS_SCREEN,
+  type PerpsPositionActionFormParams,
+} from 'src/shared/types/perps-events';
+import { emitter } from 'src/ui/shared/events';
 import { useBackgroundKind } from 'src/ui/components/Background';
 import { NavigationTitle } from 'src/ui/components/NavigationTitle';
 import { PageColumn } from 'src/ui/components/PageColumn';
@@ -214,6 +222,9 @@ export function PerpsTrade() {
       const existingIsCross =
         position != null ? position.leverage.type === 'cross' : true;
 
+      let intent: PerpsIntent;
+      let analytics: PerpsPositionActionFormParams;
+
       if (effectiveMode === 'open') {
         invariant(state.inputAmount, 'Amount is required');
         const marginUsd = Number(state.inputAmount);
@@ -286,24 +297,54 @@ export function PerpsTrade() {
           },
         });
 
-        await runPerpsIntent({
-          intent: {
-            kind: 'open',
-            coin: parsed.coin,
-            dexIdentifier: parsed.dexIdentifier,
-            asset: assetId,
-            isCross: existingIsCross,
-            desiredLeverage: effectiveLeverage,
-            order: action,
-            successText: 'Position opened',
-          },
-          context: {
-            address,
-            builder: tradingContext.builderAddress,
-            requiredMaxBuilderFee: tradingContext.maxApproveBuilderFeeUnits,
-            referralCode: tradingContext.referralCode,
-          },
-        });
+        intent = {
+          kind: 'open',
+          coin: parsed.coin,
+          dexIdentifier: parsed.dexIdentifier,
+          asset: assetId,
+          isCross: existingIsCross,
+          desiredLeverage: effectiveLeverage,
+          order: action,
+          successText: 'Position opened',
+        };
+
+        const notional = size * markPrice;
+        const floatSide = isLong ? 1 : -1;
+        const liqPrice =
+          size > 0
+            ? calculateIsolatedLiquidationPrice({
+                mid: markPrice,
+                floatSide,
+                leverage: { value: effectiveLeverage, rawUsd: 0 },
+                positionSzi: 0,
+                userSz: size,
+                totalNtlPos: notional,
+                updatedPosition: floatSide * size,
+                maxLeverage: asset.universe.maxLeverage,
+              })
+            : null;
+        const takeProfitUsd = Number(state.takeProfitPrice);
+        const stopLossUsd = Number(state.stopLossPrice);
+        analytics = {
+          position_side: isLong ? 'Long' : 'Short',
+          action_type: 'Open',
+          amount_usd: marginUsd,
+          asset_name: asset.universe.name,
+          leverage: effectiveLeverage,
+          zerion_fee_percentage: tradingContext.zerionRate * 100,
+          zerion_fee_usd_amount: notional * tradingContext.zerionRate,
+          provider_fee_percentage: tradingContext.hyperliquidRate * 100,
+          provider_fee_usd_amount: notional * tradingContext.hyperliquidRate,
+          entry_price_usd: markPrice,
+          liquidation_price_usd: liqPrice ?? 0,
+          size: notional,
+          margin: marginUsd,
+          delta_size: notional,
+          delta_margin: marginUsd,
+          screen_name: isLong ? PERPS_SCREEN.Long : PERPS_SCREEN.Short,
+          take_profit_usd: takeProfitUsd > 0 ? takeProfitUsd : undefined,
+          stop_loss_usd: stopLossUsd > 0 ? stopLossUsd : undefined,
+        };
       } else if (effectiveMode === 'add') {
         invariant(position, 'Position is required for add');
         invariant(state.inputAmount, 'Amount is required');
@@ -338,24 +379,42 @@ export function PerpsTrade() {
             f: tradingContext.builderFeeUnits,
           },
         });
-        await runPerpsIntent({
-          intent: {
-            kind: 'add',
-            coin: parsed.coin,
-            dexIdentifier: parsed.dexIdentifier,
-            asset: assetId,
-            isCross: existingIsCross,
-            desiredLeverage: positionLeverage,
-            order: action,
-            successText: 'Position updated',
-          },
-          context: {
-            address,
-            builder: tradingContext.builderAddress,
-            requiredMaxBuilderFee: tradingContext.maxApproveBuilderFeeUnits,
-            referralCode: tradingContext.referralCode,
-          },
-        });
+        intent = {
+          kind: 'add',
+          coin: parsed.coin,
+          dexIdentifier: parsed.dexIdentifier,
+          asset: assetId,
+          isCross: existingIsCross,
+          desiredLeverage: positionLeverage,
+          order: action,
+          successText: 'Position updated',
+        };
+
+        const notional = size * markPrice;
+        const existingSize = Math.abs(Number(position.positionValue));
+        const existingMargin = Number(position.marginUsed);
+        analytics = {
+          position_side: isLong ? 'Long' : 'Short',
+          action_type: 'Add',
+          amount_usd: marginUsd,
+          asset_name: asset.universe.name,
+          leverage: positionLeverage,
+          zerion_fee_percentage: tradingContext.zerionRate * 100,
+          zerion_fee_usd_amount: notional * tradingContext.zerionRate,
+          provider_fee_percentage: tradingContext.hyperliquidRate * 100,
+          provider_fee_usd_amount: notional * tradingContext.hyperliquidRate,
+          entry_price_usd: Number(position.entryPx),
+          liquidation_price_usd: position.liquidationPx
+            ? Number(position.liquidationPx)
+            : 0,
+          size: existingSize + notional,
+          margin: existingMargin + marginUsd,
+          delta_size: notional,
+          delta_margin: marginUsd,
+          screen_name: isLong
+            ? PERPS_SCREEN.AddToLong
+            : PERPS_SCREEN.AddToShort,
+        };
       } else if (effectiveMode === 'close') {
         invariant(position, 'Position is required for close');
         invariant(state.inputAmount, 'Amount is required');
@@ -390,18 +449,58 @@ export function PerpsTrade() {
             f: tradingContext.builderFeeUnits,
           },
         });
+        intent = {
+          kind: 'close',
+          coin: parsed.coin,
+          dexIdentifier: parsed.dexIdentifier,
+          asset: assetId,
+          isCross: existingIsCross,
+          desiredLeverage: position.leverage.value,
+          order: action,
+          successText:
+            closeFraction >= 1 ? 'Position closed' : 'Position updated',
+        };
+
+        const marginUsed = Number(position.marginUsed);
+        const marginBeingClosed = marginUsed * closeFraction;
+        const sizeBeingClosed = size * markPrice;
+        const totalPositionSize = positionAbsSize * markPrice;
+        const unrealizedPnl = Number(position.unrealizedPnl);
+        const scaledPnlRaw = unrealizedPnl * closeFraction;
+        // Snap to 0 to avoid misleading "-$0.00" residue from tiny floating-point math.
+        const scaledPnl = Math.abs(scaledPnlRaw) < 0.005 ? 0 : scaledPnlRaw;
+        analytics = {
+          position_side: isLong ? 'Long' : 'Short',
+          action_type: 'Close',
+          amount_usd: marginBeingClosed,
+          asset_name: asset.universe.name,
+          leverage: position.leverage.value,
+          zerion_fee_percentage: tradingContext.zerionRate * 100,
+          zerion_fee_usd_amount: sizeBeingClosed * tradingContext.zerionRate,
+          provider_fee_percentage: tradingContext.hyperliquidRate * 100,
+          provider_fee_usd_amount:
+            sizeBeingClosed * tradingContext.hyperliquidRate,
+          entry_price_usd: Number(position.entryPx),
+          liquidation_price_usd: position.liquidationPx
+            ? Number(position.liquidationPx)
+            : undefined,
+          size: totalPositionSize - sizeBeingClosed,
+          margin: marginUsed - marginBeingClosed,
+          delta_size: -sizeBeingClosed,
+          delta_margin: -marginBeingClosed,
+          screen_name: isLong
+            ? PERPS_SCREEN.CloseLong
+            : PERPS_SCREEN.CloseShort,
+          receive_usd_amount: marginBeingClosed + scaledPnl,
+          realized_pnl_usd: scaledPnl,
+        };
+      } else {
+        return;
+      }
+
+      try {
         await runPerpsIntent({
-          intent: {
-            kind: 'close',
-            coin: parsed.coin,
-            dexIdentifier: parsed.dexIdentifier,
-            asset: assetId,
-            isCross: existingIsCross,
-            desiredLeverage: position.leverage.value,
-            order: action,
-            successText:
-              closeFraction >= 1 ? 'Position closed' : 'Position updated',
-          },
+          intent,
           context: {
             address,
             builder: tradingContext.builderAddress,
@@ -409,6 +508,17 @@ export function PerpsTrade() {
             referralCode: tradingContext.referralCode,
           },
         });
+        emitter.emit('perpsPositionAction', {
+          ...analytics,
+          success_status: true,
+        });
+      } catch (error) {
+        emitter.emit('perpsPositionAction', {
+          ...analytics,
+          success_status: false,
+          backend_error_message: getError(error).message,
+        });
+        throw error;
       }
     },
     onSuccess: () => {

--- a/src/ui/pages/Perps/PerpsWithdraw/PerpsWithdraw.tsx
+++ b/src/ui/pages/Perps/PerpsWithdraw/PerpsWithdraw.tsx
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import React, { useId, useMemo, useState } from 'react';
+import React, { useEffect, useId, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { usePerpsRemoteConfig } from 'src/modules/hyperliquid/hooks/usePerpsRemoteConfig';
 import { useHyperliquidAccountSummary } from 'src/modules/hyperliquid/hooks/useHyperliquidAccountSummary';
@@ -14,6 +14,8 @@ import { BlockieImg } from 'src/ui/components/BlockieImg';
 import { useReceiverDisplayName } from 'src/ui/components/ReceiverAddressDialog';
 import { invariant } from 'src/shared/invariant';
 import { normalizeAddress } from 'src/shared/normalizeAddress';
+import { PERPS_SCREEN } from 'src/shared/types/perps-events';
+import { emitter } from 'src/ui/shared/events';
 import { truncateAddress } from 'src/ui/shared/truncateAddress';
 import { useAddressParams } from 'src/ui/shared/user-address/useAddressParams';
 import { markHyperliquidOpSubmitted } from 'src/modules/hyperliquid/useHyperliquidRefetchInterval';
@@ -61,6 +63,12 @@ function parseAmount(value: string): BigNumber {
 
 export function PerpsWithdraw() {
   useBackgroundKind({ kind: 'white' });
+  useEffect(() => {
+    emitter.emit('perpsScreenViewed', {
+      screen_name: PERPS_SCREEN.Withdraw,
+    });
+  }, []);
+
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { singleAddress: address } = useAddressParams();

--- a/src/ui/shared/events.ts
+++ b/src/ui/shared/events.ts
@@ -4,6 +4,11 @@ import type {
   BannerClickedParams,
   ButtonClickedParams,
 } from 'src/shared/types/button-events';
+import type {
+  PerpsButtonPressedParams,
+  PerpsPositionActionParams,
+  PerpsScreenViewedParams,
+} from 'src/shared/types/perps-events';
 
 type EthersSignMethod = 'sendTransaction' | '_signTypedData' | 'signMessage';
 
@@ -25,6 +30,9 @@ export const emitter = createNanoEvents<{
   buttonClicked: (data: ButtonClickedParams) => void;
   bannerClicked: (data: BannerClickedParams) => void;
   mnemonicRestorationNeeded: () => void;
+  perpsScreenViewed: (data: PerpsScreenViewedParams) => void;
+  perpsButtonPressed: (data: PerpsButtonPressedParams) => void;
+  perpsPositionAction: (data: PerpsPositionActionParams) => void;
 }>();
 
 emitter.on('mutationError', (error, _variables, context) => {


### PR DESCRIPTION
## Summary
- Add `perpsScreenViewed`, `perpsButtonPressed`, and `perpsPositionAction` events that bridge UI → background via `walletPort`, then fan out to Mixpanel (and Metabase for position actions). Mirrors the web app's payload shapes and `PERPS_SCREEN` / `PERPS_BUTTON` taxonomy, so cross-platform dashboards stay consistent.
- Wire emissions across the perps surface: screen views from the trade forms (Open/Add/Close), leverage and auto-close overlays, deposit and withdraw screens; button presses for Long/Short/Add/Close on the asset page, Deposit/Withdraw on the overview, plus Adjust Leverage / Take Profit / Stop Loss in the open form; position action emitted from `PerpsTrade.tsx` after `runPerpsIntent` resolves, with success/failure outcome and `backend_error_message` on throw.

Closes WLT-1541

## Test plan
- [ ] Open `/perps`, click Deposit → `Perps: Button Pressed` (Deposit, Overview)
- [ ] Open `/perps`, click Withdraw → `Perps: Button Pressed` (Withdraw, Overview)
- [ ] Open `/perps/deposit` → `Perps: Screen Viewed` (Deposit)
- [ ] Open `/perps/withdraw` → `Perps: Screen Viewed` (Withdraw)
- [ ] Open an asset page; click Long/Short/Add/Close → `Perps: Button Pressed` (Long/Short/Add/Close, Asset)
- [ ] On an open form (`mode=open&side=long`), see `Perps: Screen Viewed` (Long); click Leverage → `Perps: Button Pressed` (Adjust Leverage, Long) and `Perps: Screen Viewed` (Adjust Leverage); same for Take Profit / Stop Loss
- [ ] Submit an Open trade → `Perps: Position Action` with `action_type=Open`, `success_status=true` on success; `success_status=false` + `backend_error_message` on failure
- [ ] Submit Add and Close trades → same event with `action_type=Add` / `Close`, including `delta_size` / `delta_margin` / `receive_usd_amount` / `realized_pnl_usd`
- [ ] Toggle analytics off in preferences and confirm no events fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)