### PR TITLE
WLT-1637: hide balances in Perps screens

### DIFF
--- a/src/ui/pages/Perps/Blocks/HistoryBlock/HistoryBlock.tsx
+++ b/src/ui/pages/Perps/Blocks/HistoryBlock/HistoryBlock.tsx
@@ -9,6 +9,7 @@ import { Button } from 'src/ui/ui-kit/Button';
 import { HStack } from 'src/ui/ui-kit/HStack';
 import { UIText } from 'src/ui/ui-kit/UIText';
 import { VStack } from 'src/ui/ui-kit/VStack';
+import { BlurrableBalance } from 'src/ui/components/BlurrableBalance';
 
 const PAGE_SIZE = 50;
 
@@ -74,14 +75,20 @@ function FillRow({
         <UIText
           kind="small/regular"
           style={{
+            display: 'flex',
+            gap: 4,
+            alignItems: 'center',
+            minWidth: 0,
             whiteSpace: 'nowrap',
             overflow: 'hidden',
             textOverflow: 'ellipsis',
           }}
         >
-          {formatTokenValue(sz, displayName)}{' '}
-          <span style={{ color: 'var(--neutral-600)' }}>@</span>{' '}
-          {formatPriceValue(px, 'en', currency)}
+          <BlurrableBalance kind="small/regular" color="var(--black)">
+            {formatTokenValue(sz, displayName)}
+          </BlurrableBalance>
+          <span style={{ color: 'var(--neutral-600)' }}>@</span>
+          <span>{formatPriceValue(px, 'en', currency)}</span>
         </UIText>
       </HStack>
       <VStack gap={0} style={{ textAlign: 'end', flexShrink: 0 }}>
@@ -92,7 +99,14 @@ function FillRow({
               isPositivePnl ? 'var(--positive-500)' : 'var(--negative-500)'
             }
           >
-            {formatCurrencyValue(closedPnl, 'en', currency)}
+            <BlurrableBalance
+              kind="caption/accent"
+              color={
+                isPositivePnl ? 'var(--positive-500)' : 'var(--negative-500)'
+              }
+            >
+              {formatCurrencyValue(closedPnl, 'en', currency)}
+            </BlurrableBalance>
           </UIText>
         ) : null}
         <UIText kind="caption/regular" color="var(--neutral-600)">

--- a/src/ui/pages/Perps/Blocks/PositionBlock/PositionBlock.tsx
+++ b/src/ui/pages/Perps/Blocks/PositionBlock/PositionBlock.tsx
@@ -9,6 +9,7 @@ import { Frame } from 'src/ui/ui-kit/Frame';
 import { HStack } from 'src/ui/ui-kit/HStack';
 import { UIText } from 'src/ui/ui-kit/UIText';
 import { VStack } from 'src/ui/ui-kit/VStack';
+import { BlurrableBalance } from 'src/ui/components/BlurrableBalance';
 
 function DetailRow({
   label,
@@ -93,7 +94,9 @@ export function PositionBlock({
             </UIText>
             <HStack gap={8} alignItems="center">
               <UIText kind="headline/h2">
-                {formatCurrencyValue(marginUsed, 'en', currency)}
+                <BlurrableBalance kind="headline/h2" color="var(--black)">
+                  {formatCurrencyValue(marginUsed, 'en', currency)}
+                </BlurrableBalance>
               </UIText>
               <UIText
                 kind="caption/accent"
@@ -123,26 +126,46 @@ export function PositionBlock({
               label="PnL"
               valueColor={pnlColor}
               value={
-                <>
-                  {isPositivePnl ? '+' : '-'}
-                  {formatPercent(Math.abs(roe), 'en', {
-                    maximumFractionDigits: 2,
-                  })}
-                  % (
-                  {formatCurrencyValue(Math.abs(unrealizedPnl), 'en', currency)}
-                  )
-                </>
+                <span style={{ display: 'flex', gap: 4 }}>
+                  <span>
+                    {isPositivePnl ? '+' : '-'}
+                    {formatPercent(Math.abs(roe), 'en', {
+                      maximumFractionDigits: 2,
+                    })}
+                    %
+                  </span>
+                  <BlurrableBalance kind="body/accent" color={pnlColor}>
+                    (
+                    {formatCurrencyValue(
+                      Math.abs(unrealizedPnl),
+                      'en',
+                      currency
+                    )}
+                    )
+                  </BlurrableBalance>
+                </span>
               }
             />
             <GridCell
               label="Notional"
-              value={formatCurrencyValue(positionValue, 'en', currency)}
+              value={
+                <BlurrableBalance kind="body/accent" color="var(--black)">
+                  {formatCurrencyValue(positionValue, 'en', currency)}
+                </BlurrableBalance>
+              }
             />
           </div>
         </VStack>
       </Frame>
       <VStack gap={0} style={{ paddingInline: 16 }}>
-        <DetailRow label="Size" value={formatTokenValue(size, displayName)} />
+        <DetailRow
+          label="Size"
+          value={
+            <BlurrableBalance kind="body/accent" color="var(--black)">
+              {formatTokenValue(size, displayName)}
+            </BlurrableBalance>
+          }
+        />
         <DetailRow
           label="Entry Price"
           value={formatPriceValue(entryPx, 'en', currency)}
@@ -158,10 +181,10 @@ export function PositionBlock({
         <DetailRow
           label="Funding Payments"
           value={
-            <>
+            <BlurrableBalance kind="body/accent" color="var(--black)">
               {isPositiveFunding ? '' : '-'}
               {formatCurrencyValue(Math.abs(fundingSinceOpen), 'en', currency)}
-            </>
+            </BlurrableBalance>
           }
         />
       </VStack>

--- a/src/ui/pages/Perps/PerpsOverview/PerpsHistoryRows.tsx
+++ b/src/ui/pages/Perps/PerpsOverview/PerpsHistoryRows.tsx
@@ -15,6 +15,7 @@ import { TokenIcon } from 'src/ui/ui-kit/TokenIcon';
 import { UIText } from 'src/ui/ui-kit/UIText';
 import { UnstyledLink } from 'src/ui/ui-kit/UnstyledLink';
 import { VStack } from 'src/ui/ui-kit/VStack';
+import { BlurrableBalance } from 'src/ui/components/BlurrableBalance';
 
 function getDirectionLabel(fill: PerpFill): string {
   const lowered = fill.dir.toLowerCase();
@@ -119,7 +120,12 @@ export function PerpsHistoryTradeRow({
             color={trailingColor}
             style={{ flexShrink: 0 }}
           >
-            {trailing}
+            <BlurrableBalance
+              kind="body/regular"
+              color={trailingColor ?? 'var(--black)'}
+            >
+              {trailing}
+            </BlurrableBalance>
           </UIText>
         </HStack>
       </HStack>
@@ -288,7 +294,12 @@ export function PerpsHistoryLedgerRow({
           color={trailing.color}
           style={{ flexShrink: 0 }}
         >
-          {trailing.text}
+          <BlurrableBalance
+            kind="body/regular"
+            color={trailing.color ?? 'var(--black)'}
+          >
+            {trailing.text}
+          </BlurrableBalance>
         </UIText>
       </HStack>
     </HStack>

--- a/src/ui/pages/Perps/PerpsOverview/PerpsPositionCard.tsx
+++ b/src/ui/pages/Perps/PerpsOverview/PerpsPositionCard.tsx
@@ -11,6 +11,7 @@ import { TokenIcon } from 'src/ui/ui-kit/TokenIcon';
 import { UIText } from 'src/ui/ui-kit/UIText';
 import { UnstyledLink } from 'src/ui/ui-kit/UnstyledLink';
 import { VStack } from 'src/ui/ui-kit/VStack';
+import { BlurrableBalance } from 'src/ui/components/BlurrableBalance';
 import styles from './PerpsPositionCard.module.css';
 
 function StatColumn({
@@ -99,19 +100,32 @@ export function PerpsPositionCard({
           </HStack>
           <VStack gap={0} style={{ alignItems: 'flex-end', flexShrink: 0 }}>
             <UIText kind="small/accent">
-              {formatCurrencyValue(marginUsed, 'en', currency)}
+              <BlurrableBalance kind="small/accent" color="var(--black)">
+                {formatCurrencyValue(marginUsed, 'en', currency)}
+              </BlurrableBalance>
             </UIText>
             <UIText
               kind="small/regular"
               color={
                 isPositivePnl ? 'var(--positive-500)' : 'var(--negative-500)'
               }
+              style={{ display: 'flex', gap: 4 }}
             >
-              {isPositivePnl ? '+' : '-'}
-              {formatPercent(Math.abs(roe), 'en', {
-                maximumFractionDigits: 2,
-              })}
-              % ({formatCurrencyValue(Math.abs(unrealizedPnl), 'en', currency)})
+              <span>
+                {isPositivePnl ? '+' : '-'}
+                {formatPercent(Math.abs(roe), 'en', {
+                  maximumFractionDigits: 2,
+                })}
+                %
+              </span>
+              <BlurrableBalance
+                kind="small/regular"
+                color={
+                  isPositivePnl ? 'var(--positive-500)' : 'var(--negative-500)'
+                }
+              >
+                ({formatCurrencyValue(Math.abs(unrealizedPnl), 'en', currency)})
+              </BlurrableBalance>
             </UIText>
           </VStack>
         </HStack>

--- a/src/ui/pages/Perps/PerpsTrade/AddToPositionForm.tsx
+++ b/src/ui/pages/Perps/PerpsTrade/AddToPositionForm.tsx
@@ -16,6 +16,7 @@ import { HStack } from 'src/ui/ui-kit/HStack';
 import { UIText } from 'src/ui/ui-kit/UIText';
 import { UnstyledButton } from 'src/ui/ui-kit/UnstyledButton';
 import { VStack } from 'src/ui/ui-kit/VStack';
+import { BlurrableBalance } from 'src/ui/components/BlurrableBalance';
 import { CenteredAmountInput } from './CenteredAmountInput';
 import * as s from './styles.module.css';
 import type { TradeFormState } from './useTradeFormState';
@@ -118,12 +119,20 @@ export function AddToPositionForm({
         <UIText
           kind="small/accent"
           color="var(--neutral-600)"
-          style={{ textAlign: 'center' }}
+          style={{
+            display: 'flex',
+            gap: 4,
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}
         >
-          Size {formatCurrencyValue(marginUsd, 'en', currency)}
-          {addSize > 0
-            ? ` · ${formatTokenValue(addSize, asset.universe.name)}`
-            : ''}
+          <span>Size</span>
+          <BlurrableBalance kind="small/accent" color="var(--neutral-600)">
+            {formatCurrencyValue(marginUsd, 'en', currency)}
+            {addSize > 0
+              ? ` · ${formatTokenValue(addSize, asset.universe.name)}`
+              : ''}
+          </BlurrableBalance>
         </UIText>
       </VStack>
 
@@ -147,7 +156,9 @@ export function AddToPositionForm({
               Available
             </UIText>
             <UIText kind="small/accent">
-              {formatCurrencyValue(availableToTrade, 'en', currency)}
+              <BlurrableBalance kind="small/accent" color="var(--black)">
+                {formatCurrencyValue(availableToTrade, 'en', currency)}
+              </BlurrableBalance>
             </UIText>
           </HStack>
           <div className={s.frameDivider} />
@@ -156,9 +167,15 @@ export function AddToPositionForm({
               Adding to {isLong ? 'Long' : 'Short'}
             </UIText>
             <UIText kind="small/accent">
-              {positionAbsSize.toFixed(Math.max(szDecimals, 2))}{' '}
-              {getPerpDisplayName(asset.universe.name)} ·{' '}
-              {formatCurrencyValue(Number(position.marginUsed), 'en', currency)}
+              <BlurrableBalance kind="small/accent" color="var(--black)">
+                {positionAbsSize.toFixed(Math.max(szDecimals, 2))}{' '}
+                {getPerpDisplayName(asset.universe.name)} ·{' '}
+                {formatCurrencyValue(
+                  Number(position.marginUsed),
+                  'en',
+                  currency
+                )}
+              </BlurrableBalance>
             </UIText>
           </HStack>
           <div className={s.frameDivider} />
@@ -178,11 +195,15 @@ export function AddToPositionForm({
               Add size
             </UIText>
             <UIText kind="small/accent">
-              {addSize > 0
-                ? `${addSize.toFixed(Math.max(szDecimals, 2))} ${
+              {addSize > 0 ? (
+                <BlurrableBalance kind="small/accent" color="var(--black)">
+                  {`${addSize.toFixed(Math.max(szDecimals, 2))} ${
                     asset.universe.name
-                  }`
-                : '—'}
+                  }`}
+                </BlurrableBalance>
+              ) : (
+                '—'
+              )}
             </UIText>
           </HStack>
           <div className={s.frameDivider} />
@@ -206,9 +227,11 @@ export function AddToPositionForm({
             <UIText kind="small/regular" color="var(--neutral-600)">
               Fee
             </UIText>
-            <UIText kind="small/accent">
-              {(totalFeeRate * 100).toFixed(3)}% (
-              {formatCurrencyValue(feeCost, 'en', currency)})
+            <UIText kind="small/accent" style={{ display: 'flex', gap: 4 }}>
+              <span>{(totalFeeRate * 100).toFixed(3)}%</span>
+              <BlurrableBalance kind="small/accent" color="var(--black)">
+                ({formatCurrencyValue(feeCost, 'en', currency)})
+              </BlurrableBalance>
             </UIText>
           </UnstyledButton>
         </VStack>

--- a/src/ui/pages/Perps/PerpsTrade/ClosePositionForm.tsx
+++ b/src/ui/pages/Perps/PerpsTrade/ClosePositionForm.tsx
@@ -12,6 +12,7 @@ import { HStack } from 'src/ui/ui-kit/HStack';
 import { UIText } from 'src/ui/ui-kit/UIText';
 import { UnstyledButton } from 'src/ui/ui-kit/UnstyledButton';
 import { VStack } from 'src/ui/ui-kit/VStack';
+import { BlurrableBalance } from 'src/ui/components/BlurrableBalance';
 import { CenteredAmountInput } from './CenteredAmountInput';
 import * as s from './styles.module.css';
 import type { TradeFormState } from './useTradeFormState';
@@ -108,12 +109,20 @@ export function ClosePositionForm({
         <UIText
           kind="small/accent"
           color="var(--neutral-600)"
-          style={{ textAlign: 'center' }}
+          style={{
+            display: 'flex',
+            gap: 4,
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}
         >
-          Size {formatCurrencyValue(closeUsd, 'en', currency)}
-          {closeSize > 0
-            ? ` · ${formatTokenValue(closeSize, asset.universe.name)}`
-            : ''}
+          <span>Size</span>
+          <BlurrableBalance kind="small/accent" color="var(--neutral-600)">
+            {formatCurrencyValue(closeUsd, 'en', currency)}
+            {closeSize > 0
+              ? ` · ${formatTokenValue(closeSize, asset.universe.name)}`
+              : ''}
+          </BlurrableBalance>
         </UIText>
       </VStack>
 
@@ -148,8 +157,17 @@ export function ClosePositionForm({
               }}
             >
               <UIText kind="small/accent" color="inherit">
-                {isPnlPositive ? '+' : '-'}
-                {formatCurrencyValue(Math.abs(pnlOnClose), 'en', currency)}
+                <BlurrableBalance
+                  kind="small/accent"
+                  color={
+                    isPnlPositive
+                      ? 'var(--positive-500)'
+                      : 'var(--negative-500)'
+                  }
+                >
+                  {isPnlPositive ? '+' : '-'}
+                  {formatCurrencyValue(Math.abs(pnlOnClose), 'en', currency)}
+                </BlurrableBalance>
               </UIText>
             </HStack>
           </HStack>
@@ -157,10 +175,12 @@ export function ClosePositionForm({
           <HStack gap={8} justifyContent="space-between" alignItems="center">
             <UIText kind="small/accent">Receive</UIText>
             <UIText kind="small/accent">
-              {formatCurrencyValue(receiveUsd, 'en', currency)}
-              {closeSize > 0
-                ? ` (${formatTokenValue(closeSize, asset.universe.name)})`
-                : ''}
+              <BlurrableBalance kind="small/accent" color="var(--black)">
+                {formatCurrencyValue(receiveUsd, 'en', currency)}
+                {closeSize > 0
+                  ? ` (${formatTokenValue(closeSize, asset.universe.name)})`
+                  : ''}
+              </BlurrableBalance>
             </UIText>
           </HStack>
         </VStack>
@@ -173,11 +193,15 @@ export function ClosePositionForm({
               Closing size
             </UIText>
             <UIText kind="small/accent">
-              {closeSize > 0
-                ? `${closeSize.toFixed(Math.max(szDecimals, 2))} ${
+              {closeSize > 0 ? (
+                <BlurrableBalance kind="small/accent" color="var(--black)">
+                  {`${closeSize.toFixed(Math.max(szDecimals, 2))} ${
                     asset.universe.name
-                  }`
-                : '—'}
+                  }`}
+                </BlurrableBalance>
+              ) : (
+                '—'
+              )}
             </UIText>
           </HStack>
           <div className={s.frameDivider} />
@@ -186,7 +210,9 @@ export function ClosePositionForm({
               Remaining
             </UIText>
             <UIText kind="small/accent">
-              {formatCurrencyValue(remainingUsd, 'en', currency)}
+              <BlurrableBalance kind="small/accent" color="var(--black)">
+                {formatCurrencyValue(remainingUsd, 'en', currency)}
+              </BlurrableBalance>
             </UIText>
           </HStack>
           <div className={s.frameDivider} />
@@ -199,9 +225,11 @@ export function ClosePositionForm({
             <UIText kind="small/regular" color="var(--neutral-600)">
               Fee
             </UIText>
-            <UIText kind="small/accent">
-              {(totalFeeRate * 100).toFixed(3)}% (
-              {formatCurrencyValue(feeCost, 'en', currency)})
+            <UIText kind="small/accent" style={{ display: 'flex', gap: 4 }}>
+              <span>{(totalFeeRate * 100).toFixed(3)}%</span>
+              <BlurrableBalance kind="small/accent" color="var(--black)">
+                ({formatCurrencyValue(feeCost, 'en', currency)})
+              </BlurrableBalance>
             </UIText>
           </UnstyledButton>
         </VStack>

--- a/src/ui/pages/Perps/PerpsTrade/OpenPositionForm.tsx
+++ b/src/ui/pages/Perps/PerpsTrade/OpenPositionForm.tsx
@@ -14,6 +14,7 @@ import { HStack } from 'src/ui/ui-kit/HStack';
 import { UIText } from 'src/ui/ui-kit/UIText';
 import { UnstyledButton } from 'src/ui/ui-kit/UnstyledButton';
 import { VStack } from 'src/ui/ui-kit/VStack';
+import { BlurrableBalance } from 'src/ui/components/BlurrableBalance';
 import { CenteredAmountInput } from './CenteredAmountInput';
 import * as s from './styles.module.css';
 import type { TradeFormState, TradeSide } from './useTradeFormState';
@@ -147,9 +148,17 @@ export function OpenPositionForm({
         <UIText
           kind="caption/regular"
           color="var(--neutral-600)"
-          style={{ textAlign: 'center' }}
+          style={{
+            display: 'flex',
+            gap: 4,
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}
         >
-          Available {formatCurrencyValue(availableToTrade, 'en', currency)}
+          <span>Available</span>
+          <BlurrableBalance kind="caption/regular" color="var(--neutral-600)">
+            {formatCurrencyValue(availableToTrade, 'en', currency)}
+          </BlurrableBalance>
         </UIText>
       </VStack>
 
@@ -229,11 +238,15 @@ export function OpenPositionForm({
               Order size
             </UIText>
             <UIText kind="small/accent">
-              {positionSize > 0
-                ? `${positionSize.toFixed(Math.max(szDecimals, 2))} ${
+              {positionSize > 0 ? (
+                <BlurrableBalance kind="small/accent" color="var(--black)">
+                  {`${positionSize.toFixed(Math.max(szDecimals, 2))} ${
                     asset.universe.name
-                  }`
-                : '—'}
+                  }`}
+                </BlurrableBalance>
+              ) : (
+                '—'
+              )}
             </UIText>
           </HStack>
           <div className={s.frameDivider} />
@@ -246,9 +259,11 @@ export function OpenPositionForm({
             <UIText kind="small/regular" color="var(--neutral-600)">
               Fee
             </UIText>
-            <UIText kind="small/accent">
-              {(totalFeeRate * 100).toFixed(3)}% (
-              {formatCurrencyValue(feeCost, 'en', currency)})
+            <UIText kind="small/accent" style={{ display: 'flex', gap: 4 }}>
+              <span>{(totalFeeRate * 100).toFixed(3)}%</span>
+              <BlurrableBalance kind="small/accent" color="var(--black)">
+                ({formatCurrencyValue(feeCost, 'en', currency)})
+              </BlurrableBalance>
             </UIText>
           </UnstyledButton>
         </VStack>

--- a/src/ui/pages/Perps/PerpsWithdraw/PerpsWithdraw.tsx
+++ b/src/ui/pages/Perps/PerpsWithdraw/PerpsWithdraw.tsx
@@ -28,6 +28,7 @@ import { UnstyledInput } from 'src/ui/ui-kit/UnstyledInput';
 import { UnstyledLink } from 'src/ui/ui-kit/UnstyledLink';
 import { VStack } from 'src/ui/ui-kit/VStack';
 import { WalletAvatar } from 'src/ui/components/WalletAvatar';
+import { BlurrableBalance } from 'src/ui/components/BlurrableBalance';
 import * as s from './styles.module.css';
 
 const MIN_WITHDRAW_USD = 5;
@@ -269,8 +270,18 @@ export function PerpsWithdraw() {
                   style={{ width: 132, height: 16 }}
                 />
               ) : (
-                <UIText kind="small/regular" color="var(--neutral-600)">
-                  {`Available ${formatUsd(withdrawable.toFixed())}`}
+                <UIText
+                  kind="small/regular"
+                  color="var(--neutral-600)"
+                  style={{ display: 'flex', gap: 4 }}
+                >
+                  <span>Available</span>
+                  <BlurrableBalance
+                    kind="small/regular"
+                    color="var(--neutral-600)"
+                  >
+                    {formatUsd(withdrawable.toFixed())}
+                  </BlurrableBalance>
                 </UIText>
               )}
               {errorText ? (


### PR DESCRIPTION
## Summary

Respects the **Hide Balances** privacy setting (Settings → Privacy, or `Shift+H`) across the Perps screens, which were never wired up to it. Money amounts are wrapped in the existing `BlurrableBalance` component.

**Blurs** amounts that reveal how much money you have:
- Overview position card — margin, unrealized PnL $ (the `$` part of `X% ($Y)`)
- Overview history dialog — trade/ledger amounts
- Withdraw form — "Available $X" (label stays visible)
- Perp detail PositionBlock — margin, notional, size (tokens), PnL $, funding payments
- Perp detail HistoryBlock — fill size (tokens), closed PnL
- Open / Close / Add position forms — available-to-trade, order/closing/add size (USD + tokens), PnL on close, amount-to-receive, remaining value, fee `$`

**Keeps visible** (market data / not your balance): mark, entry & liquidation prices, 24h volume, open interest, funding rate, and all percentages (24h % change, ROE %, fee % rate). For relative change `X% ($Y)`, only `$Y` is blurred — matching the main Positions list. Editable amount inputs stay visible (matches the existing Swap/Send forms).

The account value on the overview was already wrapped; no other "out of scope" surfaces (Heading, StatsBlock, PerpScrolledHeader, PerpsMarketRow) were touched.

The blur/keep rule was decided in a grilling session and captured as a [PRD comment](https://linear.app/zerion/issue/WLT-1637/extension-hide-balances-in-perps-screens) on the Linear issue before implementation.

Closes WLT-1637

## Test plan
- Toggle Hide Balances via `Shift+H` (or Settings → Privacy).
- Open the Perps overview: account value, position-card margin and the `($PnL)` portion blur; entry/market/liq prices and the `%` stay visible.
- Open the overview Perps history dialog: trade and ledger amounts blur.
- Open a Perp detail page: margin, notional, size, PnL `$`, funding blur; prices and stats (volume/OI/funding) stay visible. History rows blur size + closed PnL, keep `@ price`.
- Open the withdraw form: "Available" amount blurs, typed amount stays visible.
- Open the Open / Close / Add position forms: available, sizes, PnL, receive, remaining, fee `$` blur; prices and `%` stay visible; the amount you type stays visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)