### PR TITLE
WLT-1580: remove Custom Data toggle from Developer Tools

### DIFF
--- a/src/ui/pages/Settings/Settings.tsx
+++ b/src/ui/pages/Settings/Settings.tsx
@@ -455,16 +455,6 @@ function DeveloperTools() {
             }
           />
           <ToggleSettingLine
-            text="Custom Data"
-            checked={preferences?.configurableTransactionData ?? false}
-            onChange={(event) => {
-              setPreferences({
-                configurableTransactionData: event.target.checked,
-              });
-            }}
-            detailText={<span>Attach arbitrary data to Send transactions</span>}
-          />
-          <ToggleSettingLine
             text="Recognizable Connect Buttons"
             checked={globalPreferences?.recognizableConnectButtons || false}
             onChange={(event) => {


### PR DESCRIPTION
## Summary
Removes the **Custom Data** toggle from Settings → Developer Tools. This was a niche, technical feature (attach arbitrary hex data to Send transactions on native EVM sends) with effectively no usage.

**Scope: toggle UI only.** Only the `ToggleSettingLine` block is removed. The underlying `configurableTransactionData` preference (type + default) and the SendForm-gated data textarea / `prepareSendData` handling are intentionally left in place — they simply become unreachable (preference stays at its `false` default). The `Custom Nonce` and `Recognizable Connect Buttons` toggles are untouched.

Closes WLT-1580

## Test plan
- [ ] Open Settings → Developer Tools — the "Custom Data" row no longer appears.
- [ ] "Custom Nonce" and "Recognizable Connect Buttons" toggles still render and work.
- [ ] Send form behaves as before (no custom-data textarea, since the preference defaults to off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)