### PR TITLE
WLT-1645: fix dark theme text in High Price Impact warning

### DIFF
--- a/src/ui/pages/SwapForm2/PriceImpactWarning/PriceImpactWarning.tsx
+++ b/src/ui/pages/SwapForm2/PriceImpactWarning/PriceImpactWarning.tsx
@@ -39,7 +39,7 @@ export function PriceImpactWarning({
     }
     return (
       <div className={styles.pillNeutral}>
-        <UIText kind="small/accent" color="var(--black)">
+        <UIText kind="small/accent" color="var(--always-black)">
           High Price Impact
         </UIText>
         <UIText kind="small/accent" color="var(--negative-500)">


### PR DESCRIPTION
## Summary

The **High Price Impact** warning pill in the swap form had an invisible label in dark theme: the `High Price Impact` text used `color="var(--black)"`, which resolves to white (`#ffffff`) in dark mode. The pill background is always light (`var(--neutral-background)` is never defined and falls back to `#f5f5f7`), so the white label ended up white-on-light and unreadable.

This swaps the label color to `var(--always-black)` (always `#16161a`), so it stays dark in both light and dark themes, matching the always-light pill background. The red `−98.97%` percentage already used `var(--negative-500)` and was unaffected.

Closes WLT-1645

## Test plan
- Open the Swap form and produce a high-price-impact quote (e.g. a thin-liquidity pair) so the **High Price Impact** pill appears.
- In **dark theme**: the "High Price Impact" label is dark and clearly readable on the light pill; the percentage stays red.
- In **light theme**: no visual regression — label remains dark, pill remains light.

🤖 Generated with [Claude Code](https://claude.com/claude-code)