### PR TITLE
WLT-1651: bring back custom data in SendForm2

### DIFF
--- a/src/ui/pages/SendForm2/SendDetails/SendDetails.module.css
+++ b/src/ui/pages/SendForm2/SendDetails/SendDetails.module.css
@@ -53,3 +53,27 @@
 .detailLinkRow:hover .detailLinkChevron {
   color: var(--black);
 }
+
+.dataInput {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 12px;
+  border: 2px solid var(--neutral-200);
+  border-radius: 12px;
+  background-color: var(--white);
+  color: var(--black);
+  font-family: inherit;
+  font-size: 14px;
+  line-height: 20px;
+  resize: vertical;
+  outline: none;
+  transition: border-color 0.15s ease;
+}
+
+.dataInput:focus {
+  border-color: var(--primary);
+}
+
+.dataInput::placeholder {
+  color: var(--neutral-500);
+}

--- a/src/ui/pages/SendForm2/SendDetails/SendDetails.tsx
+++ b/src/ui/pages/SendForm2/SendDetails/SendDetails.tsx
@@ -93,6 +93,9 @@ export function SendDetails({
   onConfigurationChange,
   userNonce,
   onNonceChange,
+  isNativeAsset,
+  customData,
+  onCustomDataChange,
   isLoading,
   receivedAmount,
   typedAmount,
@@ -109,6 +112,9 @@ export function SendDetails({
   onConfigurationChange: (configuration: CustomConfiguration) => void;
   userNonce: string | null;
   onNonceChange: (nonce: string | null) => void;
+  isNativeAsset: boolean;
+  customData: string | null;
+  onCustomDataChange: (value: string) => void;
   isLoading: boolean;
   receivedAmount?: Amount | null;
   typedAmount?: string | null;
@@ -124,6 +130,14 @@ export function SendDetails({
   const customDefaults = getCustomFormDefaults(sendQuote);
   const showNonce = Boolean(
     preferences?.configurableNonce && isEthereumAddress(address)
+  );
+  // Custom data: gated behind the Developer Tools toggle, EVM native-asset
+  // sends only (mirrors the old SendForm's `configurableTransactionData &&
+  // isNativeAsset && addressType === 'evm'`).
+  const showData = Boolean(
+    preferences?.configurableTransactionData &&
+      isNativeAsset &&
+      isEthereumAddress(address)
   );
 
   const chain = createChain(inputChain);
@@ -241,6 +255,23 @@ export function SendDetails({
                             <DetailRow label="Nonce" value={noValueDash} />
                           )}
                         </React.Suspense>
+                      ) : null}
+                      {showData ? (
+                        <VStack gap={8}>
+                          <UIText kind="small/regular">Data</UIText>
+                          <textarea
+                            name="data"
+                            value={customData ?? ''}
+                            onChange={(event) =>
+                              onCustomDataChange(event.currentTarget.value)
+                            }
+                            className={styles.dataInput}
+                            rows={2}
+                            placeholder="0x..."
+                            spellCheck={false}
+                            autoComplete="off"
+                          />
+                        </VStack>
                       ) : null}
                       <DetailRow
                         label="Network"

--- a/src/ui/pages/SendForm2/SendForm2.tsx
+++ b/src/ui/pages/SendForm2/SendForm2.tsx
@@ -197,6 +197,14 @@ function SendFormComponent({
     return networks.getNetworkByName(createChain(formState.inputChain)) ?? null;
   }, [networks, formState.inputChain]);
 
+  // Custom data is only meaningful for native-asset EVM sends — for ERC-20 the
+  // `data` field already carries the transfer calldata. Same comparison the old
+  // SendForm used (selected fungible id === the network's native asset id).
+  const isNativeAsset = Boolean(
+    sendNetwork?.native_asset?.id &&
+      formState.inputFungibleId === sendNetwork.native_asset.id
+  );
+
   const { data: sendData, isLoading: sendDataLoading } = useSendTransaction({
     address,
     formState,
@@ -236,6 +244,13 @@ function SendFormComponent({
     if (!clientTx.evm) {
       return clientTx;
     }
+    // Inject user-entered custom data (native EVM sends only). Done here, not at
+    // sign time, so the simulated tx reflects the data too. This is the
+    // backend-tx analog of how the old SendForm merged data in prepareSendData.
+    const evmWithData =
+      isNativeAsset && formState.data
+        ? { ...clientTx.evm, data: formState.data }
+        : clientTx.evm;
     // Only apply the network-fee configuration when the user has actually
     // overridden a fee field. With everything default, the backend tx already
     // carries the right gas, so applying would just re-derive it (and would
@@ -247,15 +262,15 @@ function SendFormComponent({
       formState.gasLimit ||
       formState.networkFeeSpeed;
     if (!hasNetworkFeeOverride) {
-      return { evm: clientTx.evm };
+      return { evm: evmWithData };
     }
     const configured = applyConfiguration(
-      clientTx.evm,
+      evmWithData,
       toConfiguration(formState),
       gasPrices ?? null
     );
     return { evm: configured };
-  }, [sendQuote, formState, gasPrices]);
+  }, [sendQuote, formState, gasPrices, isNativeAsset]);
 
   // Reset simulation/sign state when form state changes meaningfully.
   const [simulationResult, setSimulationResult] =
@@ -625,6 +640,11 @@ function SendFormComponent({
               userNonce={formState.nonce ?? null}
               onNonceChange={(nonce) =>
                 handleChange('nonce', nonce ?? undefined)
+              }
+              isNativeAsset={isNativeAsset}
+              customData={formState.data ?? null}
+              onCustomDataChange={(value) =>
+                handleChange('data', value || undefined)
               }
               isLoading={sendDataLoading}
               receivedAmount={sendInputAmount}

--- a/src/ui/pages/SendForm2/useSendTransaction.ts
+++ b/src/ui/pages/SendForm2/useSendTransaction.ts
@@ -174,7 +174,9 @@ export function useSendTransaction({
 
   // Gas overrides are applied at sign time (via applyConfiguration), not in the
   // prep query — strip them here so the local path stays gas-unapplied and
-  // matches the backend path's shape.
+  // matches the backend path's shape. Custom `data` is likewise injected later
+  // (in SendForm2's clientTransaction memo) so both paths inject it in one
+  // place; strip it here to avoid prepareSendData merging it a second time.
   const legacyFormState = useMemo(() => {
     const base = toLegacySendFormState(formState, resolvedInputAmount);
     return {
@@ -185,6 +187,7 @@ export function useSendTransaction({
       gasPrice: undefined,
       gasLimit: undefined,
       nonce: undefined,
+      data: undefined,
     };
   }, [formState, resolvedInputAmount]);
 

--- a/src/ui/pages/Settings/Settings.tsx
+++ b/src/ui/pages/Settings/Settings.tsx
@@ -453,6 +453,16 @@ function DeveloperTools() {
             }
           />
           <ToggleSettingLine
+            text="Custom Data"
+            checked={preferences?.configurableTransactionData ?? false}
+            onChange={(event) => {
+              setPreferences({
+                configurableTransactionData: event.target.checked,
+              });
+            }}
+            detailText={<span>Attach arbitrary data to Send transactions</span>}
+          />
+          <ToggleSettingLine
             text="Recognizable Connect Buttons"
             checked={globalPreferences?.recognizableConnectButtons || false}
             onChange={(event) => {


### PR DESCRIPTION
## Summary

Restores the **Custom Data** toggle in Settings → Developer Tools (removed in #948) and adds a custom-data field to **SendForm2** so a user can attach arbitrary calldata to a **native EVM send**, mirroring the old SendForm.

### What changed
- **Settings:** re-add the `configurableTransactionData` `ToggleSettingLine` in its original spot (between Custom Nonce and Recognizable Connect Buttons).
- **SendForm2:** compute `isNativeAsset` and inject `formState.data` into the client transaction inside the existing `clientTransaction` memo — *before* `applyConfiguration` — so both the **simulated** and **signed** tx carry the custom data. This is the backend-tx analog of how the old SendForm merged data in `prepareSendData`.
- **useSendTransaction:** strip `data` from the legacy form state (like gas/nonce already are), so the local prep path no longer merges it. Both prep paths now inject data in one place.
- **SendDetails:** render a "Data" textarea (no validation, placeholder `0x...`) inside the collapsible Details panel, next to Nonce — gated on `configurableTransactionData && isNativeAsset && EVM address`.

A PRD with the design decisions was posted as a comment on the Linear issue before implementation.

## Test plan
1. Settings → Developer Tools → enable **Custom Data**.
2. Open Send (SendForm2), select a **native asset** (e.g. ETH) on an EVM chain, set a recipient + amount.
3. Expand **Details** → confirm a **Data** field appears; enter e.g. `0x1234`.
4. Confirm the simulation/sign uses the data (tx interpretation reflects it) and the send goes through.
5. Switch to an **ERC-20** or **NFT**, or a **Solana** account → Data field is hidden.
6. Toggle **Custom Data** off → field disappears everywhere.

Closes WLT-1651