### PR TITLE
WLT-1686: fix NaN for mixed-case hex Permit approval amount

### DIFF
--- a/src/shared/units/convert.test.ts
+++ b/src/shared/units/convert.test.ts
@@ -1,4 +1,4 @@
-import { baseToCommon, commonToBase } from './convert';
+import { baseToCommon, commonToBase, normalizeNumberValue } from './convert';
 
 test('baseToCommon', () => {
   expect(baseToCommon('8408943752575239', 18).toString()).toBe(
@@ -7,6 +7,33 @@ test('baseToCommon', () => {
   expect(baseToCommon('33871609663570237017', 18).toString()).toBe(
     '33.871609663570237017'
   );
+});
+
+test('baseToCommon parses hex-encoded values', () => {
+  // 0xDE0B6B3A7640000 === 10 ** 18 (mixed-case hex, which bignumber.js
+  // mishandles on its own, returning NaN)
+  expect(baseToCommon('0xDE0b6B3a7640000', 18).toFixed()).toBe('1');
+  // The value from WLT-1686: bignumber.js returns NaN for this mixed-case hex
+  expect(baseToCommon('0xFFFFFFFFFFFEFFFFFFfFFFFFFFFFFFF', 18).isNaN()).toBe(
+    false
+  );
+  expect(baseToCommon('0xFFFFFFFFFFFEFFFFFFfFFFFFFFFFFFF', 18).toFixed()).toBe(
+    baseToCommon('21267647932558578408597187050162094079', 18).toFixed()
+  );
+});
+
+test('normalizeNumberValue', () => {
+  // mixed-case hex -> decimal string
+  expect(normalizeNumberValue('0xFFFFFFFFFFFEFFFFFFfFFFFFFFFFFFF')).toBe(
+    '21267647932558578408597187050162094079'
+  );
+  expect(normalizeNumberValue('0xff')).toBe('255');
+  // non-hex input is passed through unchanged
+  expect(normalizeNumberValue('33871609663570237017')).toBe(
+    '33871609663570237017'
+  );
+  expect(normalizeNumberValue('33.871')).toBe('33.871');
+  expect(normalizeNumberValue(42)).toBe(42);
 });
 
 test('commonToBase', () => {

--- a/src/shared/units/convert.ts
+++ b/src/shared/units/convert.ts
@@ -1,9 +1,28 @@
 import { BigNumber } from 'bignumber.js';
 
+const HEX_STRING_PATTERN = /^0x[0-9a-f]+$/i;
+
+/**
+ * bignumber.js parses all-uppercase or all-lowercase 0x-hex strings, but
+ * returns NaN for mixed-case hex (e.g. `new BigNumber('0xFf')` -> NaN).
+ * EIP-712 uint256 fields (e.g. a Permit `value`) can legitimately arrive as
+ * mixed-case hex, so normalize any 0x-prefixed hex string to a decimal string
+ * via BigInt (which parses hex case-insensitively) before handing it to
+ * bignumber.js.
+ */
+export function normalizeNumberValue(value: BigNumber.Value): BigNumber.Value {
+  if (typeof value === 'string' && HEX_STRING_PATTERN.test(value)) {
+    return BigInt(value).toString();
+  }
+  return value;
+}
+
 export function baseToCommon(value: BigNumber.Value, decimalPlaces: number) {
-  return new BigNumber(value).shiftedBy(0 - decimalPlaces);
+  return new BigNumber(normalizeNumberValue(value)).shiftedBy(
+    0 - decimalPlaces
+  );
 }
 
 export function commonToBase(value: BigNumber.Value, decimalPlaces: number) {
-  return new BigNumber(value).shiftedBy(decimalPlaces);
+  return new BigNumber(normalizeNumberValue(value)).shiftedBy(decimalPlaces);
 }

--- a/src/shared/units/convert.ts
+++ b/src/shared/units/convert.ts
@@ -1,6 +1,5 @@
 import { BigNumber } from 'bignumber.js';
-
-const HEX_STRING_PATTERN = /^0x[0-9a-f]+$/i;
+import { isHexString } from 'ethers';
 
 /**
  * bignumber.js parses all-uppercase or all-lowercase 0x-hex strings, but
@@ -11,7 +10,9 @@ const HEX_STRING_PATTERN = /^0x[0-9a-f]+$/i;
  * bignumber.js.
  */
 export function normalizeNumberValue(value: BigNumber.Value): BigNumber.Value {
-  if (typeof value === 'string' && HEX_STRING_PATTERN.test(value)) {
+  // isHexString also returns true for a bare '0x', which BigInt can't parse,
+  // so require at least one hex digit.
+  if (isHexString(value) && value.length > 2) {
     return BigInt(value).toString();
   }
   return value;

--- a/src/ui/components/AllowanceView/AllowanceView.tsx
+++ b/src/ui/components/AllowanceView/AllowanceView.tsx
@@ -11,6 +11,7 @@ import { usePositionsRefetchInterval } from 'src/ui/transactions/usePositionsRef
 import type { NetworkConfig } from 'src/modules/networks/NetworkConfig';
 import { createChain } from 'src/modules/networks/Chain';
 import type { AnyAddressAction } from 'src/modules/ethereum/transactions/addressAction';
+import { normalizeNumberValue } from 'src/shared/units/convert';
 import { AllowanceForm } from '../AllowanceForm';
 import { NavigationBar } from '../NavigationBar';
 
@@ -82,9 +83,13 @@ export function AllowanceView({
         address={address}
         balance={balance}
         requestedAllowanceQuantityBase={
-          new BigNumber(requestedAllowanceQuantityBase)
+          new BigNumber(normalizeNumberValue(requestedAllowanceQuantityBase))
         }
-        value={new BigNumber(value || requestedAllowanceQuantityBase)}
+        value={
+          new BigNumber(
+            normalizeNumberValue(value || requestedAllowanceQuantityBase)
+          )
+        }
         onSubmit={onChange}
         footerRenderArea="sign-transaction-footer"
         addressAction={addressAction}


### PR DESCRIPTION
## Summary

An EIP-712 Permit `value` supplied as a **mixed-case** hex string (e.g. `0xFFFFFFFFFFFEFFFFFFfFFFFFFFFFFFF`) rendered as `NaN mETH` in the approval UI.

Root cause: `bignumber.js` parses all-uppercase (`0xFF`) or all-lowercase (`0xff`) hex, but returns `NaN` for mixed-case hex — `new BigNumber('0xFf')` → `NaN`. The raw Permit `value` flows into `baseToCommon` (`new BigNumber(value)`) in `SignTypedData.tsx` and into `new BigNumber(...)` in `AllowanceView`. The reported value is a valid uint256 (≈`2.13e19` base units, not max-uint256), so the fix is to parse it correctly and show the real amount.

## Changes

- Add exported `normalizeNumberValue` in `src/shared/units/convert.ts` — converts any `0x`-hex string to a decimal string via `BigInt` (case-insensitive) before handing it to bignumber.js; non-hex input passes through unchanged.
- Route `baseToCommon` / `commonToBase` through it, plus `AllowanceView`'s two direct `new BigNumber(...)` constructions.
- Unit tests in `convert.test.ts` for the reported value + regressions.

**Parse-only, display-only.** No change to signing behaviour — the signed payload keeps the dApp's original `message.value`. Verified that ethers v6 `TypedDataEncoder.hash` produces byte-identical hashes for the hex and decimal forms of the same uint256, so the signature is unaffected.

Closes WLT-1686

## Test plan

- `test:unit src/shared/units/convert.test.ts` — passes (hex parse + regressions).
- `type-check`, `lint`, `prettier` — clean.
- Manual: request `eth_signTypedData_v4` for a Permit with `value: "0xFFFFFFFFFFFEFFFFFFfFFFFFFFFFFFF"` → approval UI shows the real amount instead of `NaN`; "Edit allowance" screen shows the amount too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)