### PR TITLE
WLT-1685: sanitize EIP-712 chainId in interpretation request

### DIFF
--- a/src/background/Wallet/Wallet.ts
+++ b/src/background/Wallet/Wallet.ts
@@ -45,7 +45,10 @@ import type { Chain } from 'src/modules/networks/Chain';
 import { createChain } from 'src/modules/networks/Chain';
 import { prepareGasAndNetworkFee } from 'src/modules/ethereum/transactions/fetchAndAssignGasPrice';
 import type { TypedData } from 'src/modules/ethereum/message-signing/TypedData';
-import { prepareTypedData } from 'src/modules/ethereum/message-signing/prepareTypedData';
+import {
+  prepareTypedData,
+  sanitizeTypedDataRaw,
+} from 'src/modules/ethereum/message-signing/prepareTypedData';
 import { toUtf8String } from 'src/modules/ethereum/message-signing/toUtf8String';
 import { removeSignature } from 'src/modules/ethereum/transactions/removeSignature';
 import { normalizeAddress } from 'src/shared/normalizeAddress';
@@ -2646,8 +2649,7 @@ class PublicController {
         `Address parameter is different from currently selected address. Expected: ${currentAddress}, received: ${address}`
       );
     }
-    const stringifiedData =
-      typeof data === 'string' ? data : JSON.stringify(data);
+    const stringifiedData = sanitizeTypedDataRaw(data);
     const currentWallet = await this.wallet.uiGetCurrentWallet({
       context: INTERNAL_SYMBOL_CONTEXT,
     });

--- a/src/modules/ethereum/message-signing/prepareTypedData.test.ts
+++ b/src/modules/ethereum/message-signing/prepareTypedData.test.ts
@@ -1,0 +1,57 @@
+import type { TypedData } from './TypedData';
+import { sanitizeTypedData } from './prepareTypedData';
+
+function createTypedData(chainId?: string | number): TypedData {
+  return {
+    domain: {
+      name: 'USD Coin',
+      version: '2',
+      ...(chainId === undefined ? null : { chainId }),
+      verifyingContract: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+    },
+    types: {
+      Permit: [
+        { name: 'owner', type: 'address' },
+        { name: 'spender', type: 'address' },
+        { name: 'value', type: 'uint256' },
+        { name: 'nonce', type: 'uint256' },
+        { name: 'deadline', type: 'uint256' },
+      ],
+    },
+    primaryType: 'Permit',
+    message: {
+      owner: '0xE093d671dA3D42fBf79BC333692a7A5f794EdDFb',
+      spender: '0x6a6394f47dd0baf794808f2749c09bd4ee874e70',
+      value: '1000000',
+      nonce: 5,
+      deadline: 1800000000,
+    },
+  };
+}
+
+describe('sanitizeTypedData', () => {
+  test('trims whitespace-padded string chainId', () => {
+    expect(sanitizeTypedData(createTypedData(' 1')).domain.chainId).toBe('1');
+    expect(sanitizeTypedData(createTypedData('1 ')).domain.chainId).toBe('1');
+    expect(sanitizeTypedData(createTypedData(' 0x89 ')).domain.chainId).toBe(
+      '0x89'
+    );
+  });
+
+  test('does not mutate the input typedData', () => {
+    const typedData = createTypedData(' 1');
+    sanitizeTypedData(typedData);
+    expect(typedData.domain.chainId).toBe(' 1');
+  });
+
+  test('returns well-formed typedData unchanged', () => {
+    const asNumber = createTypedData(1);
+    expect(sanitizeTypedData(asNumber)).toBe(asNumber);
+    const asString = createTypedData('1');
+    expect(sanitizeTypedData(asString)).toBe(asString);
+    const asHexString = createTypedData('0x1');
+    expect(sanitizeTypedData(asHexString)).toBe(asHexString);
+    const withoutChainId = createTypedData();
+    expect(sanitizeTypedData(withoutChainId)).toBe(withoutChainId);
+  });
+});

--- a/src/modules/ethereum/message-signing/prepareTypedData.test.ts
+++ b/src/modules/ethereum/message-signing/prepareTypedData.test.ts
@@ -1,5 +1,5 @@
 import type { TypedData } from './TypedData';
-import { sanitizeTypedData } from './prepareTypedData';
+import { sanitizeTypedData, sanitizeTypedDataRaw } from './prepareTypedData';
 
 function createTypedData(chainId?: string | number): TypedData {
   return {
@@ -53,5 +53,31 @@ describe('sanitizeTypedData', () => {
     expect(sanitizeTypedData(asHexString)).toBe(asHexString);
     const withoutChainId = createTypedData();
     expect(sanitizeTypedData(withoutChainId)).toBe(withoutChainId);
+  });
+});
+
+describe('sanitizeTypedDataRaw', () => {
+  test('trims whitespace-padded string chainId in a stringified payload', () => {
+    const raw = JSON.stringify(createTypedData(' 1'));
+    expect(JSON.parse(sanitizeTypedDataRaw(raw)).domain.chainId).toBe('1');
+  });
+
+  test('accepts typedData objects', () => {
+    const sanitized = sanitizeTypedDataRaw(createTypedData(' 0x89 '));
+    expect(JSON.parse(sanitized).domain.chainId).toBe('0x89');
+  });
+
+  test('preserves well-formed payloads', () => {
+    const typedData = createTypedData(1);
+    expect(sanitizeTypedDataRaw(JSON.stringify(typedData))).toBe(
+      JSON.stringify(typedData)
+    );
+    expect(sanitizeTypedDataRaw(typedData)).toBe(JSON.stringify(typedData));
+  });
+
+  test('returns malformed payloads unchanged', () => {
+    expect(sanitizeTypedDataRaw('not json')).toBe('not json');
+    expect(sanitizeTypedDataRaw('{"domain":{}}')).toBe('{"domain":{}}');
+    expect(sanitizeTypedDataRaw({ domain: {} })).toBe('{"domain":{}}');
   });
 });

--- a/src/modules/ethereum/message-signing/prepareTypedData.ts
+++ b/src/modules/ethereum/message-signing/prepareTypedData.ts
@@ -37,6 +37,23 @@ export function prepareTypedData(data: string | Partial<TypedData>): TypedData {
   };
 }
 
+/**
+ * A whitespace-padded domain chainId (e.g. " 1") is tolerated during signing
+ * (ethers coerces it with BigInt, which trims whitespace), but breaks the
+ * interpretation backend. Sanitize it so interpretation runs on the same
+ * value that gets signed. Well-formed payloads are returned unchanged.
+ */
+export function sanitizeTypedData(typedData: TypedData): TypedData {
+  const { chainId } = typedData.domain;
+  if (typeof chainId === 'string' && chainId.trim() !== chainId) {
+    return {
+      ...typedData,
+      domain: { ...typedData.domain, chainId: chainId.trim() },
+    };
+  }
+  return typedData;
+}
+
 const ESCAPE_ARRAY_SYMBOLS_PATTERN = /^([^\x5b]*)(\x5b|$)/;
 
 // based on https://github.com/ethers-io/ethers.js/blob/13593809bd61ef24c01d79de82563540d77098db/src.ts/hash/typed-data.ts#L210

--- a/src/modules/ethereum/message-signing/prepareTypedData.ts
+++ b/src/modules/ethereum/message-signing/prepareTypedData.ts
@@ -54,6 +54,18 @@ export function sanitizeTypedData(typedData: TypedData): TypedData {
   return typedData;
 }
 
+export function sanitizeTypedDataRaw(
+  data: string | Partial<TypedData>
+): string {
+  try {
+    return JSON.stringify(sanitizeTypedData(toTypedData(data)));
+  } catch {
+    // Malformed payloads pass through unchanged so that downstream
+    // validation reports the error to the user as before
+    return typeof data === 'string' ? data : JSON.stringify(data);
+  }
+}
+
 const ESCAPE_ARRAY_SYMBOLS_PATTERN = /^([^\x5b]*)(\x5b|$)/;
 
 // based on https://github.com/ethers-io/ethers.js/blob/13593809bd61ef24c01d79de82563540d77098db/src.ts/hash/typed-data.ts#L210

--- a/src/shared/normalizeChainId.test.ts
+++ b/src/shared/normalizeChainId.test.ts
@@ -12,4 +12,8 @@ test('normalizeChainId', () => {
   expect(normalizeChainId(42161)).toBe('0xa4b1');
   expect(normalizeChainId('42161')).toBe('0xa4b1');
   expect(normalizeChainId('0xa4b1')).toBe('0xa4b1');
+
+  expect(normalizeChainId(' 1')).toBe('0x1');
+  expect(normalizeChainId('1 ')).toBe('0x1');
+  expect(normalizeChainId(' 0x89 ')).toBe('0x89');
 });

--- a/src/shared/normalizeChainId.ts
+++ b/src/shared/normalizeChainId.ts
@@ -5,5 +5,6 @@ import { valueToHex } from './units/valueToHex';
 export function normalizeChainId(
   value: string | number | bigint | BigNumber
 ): ChainId {
-  return valueToHex(value).toLowerCase() as ChainId;
+  const sanitized = typeof value === 'string' ? value.trim() : value;
+  return valueToHex(sanitized).toLowerCase() as ChainId;
 }

--- a/src/ui/shared/requests/interpret.ts
+++ b/src/ui/shared/requests/interpret.ts
@@ -6,7 +6,6 @@ import type { SignatureInterpretResponse } from 'src/modules/zerion-api/requests
 import { ZerionAPI } from 'src/modules/zerion-api/zerion-api.client';
 import { invariant } from 'src/shared/invariant';
 import type { TransactionEVM } from 'src/shared/types/Quote';
-import { sanitizeTypedData } from 'src/modules/ethereum/message-signing/prepareTypedData';
 import type { TypedData } from '../../../modules/ethereum/message-signing/TypedData';
 import { getGas } from '../../../modules/ethereum/transactions/getGas';
 
@@ -114,7 +113,7 @@ export function interpretSignature(
       chain,
       currency,
       domain: origin,
-      signature: { typedData: sanitizeTypedData(typedData) },
+      signature: { typedData },
     },
     { source }
   );

--- a/src/ui/shared/requests/interpret.ts
+++ b/src/ui/shared/requests/interpret.ts
@@ -6,6 +6,7 @@ import type { SignatureInterpretResponse } from 'src/modules/zerion-api/requests
 import { ZerionAPI } from 'src/modules/zerion-api/zerion-api.client';
 import { invariant } from 'src/shared/invariant';
 import type { TransactionEVM } from 'src/shared/types/Quote';
+import { sanitizeTypedData } from 'src/modules/ethereum/message-signing/prepareTypedData';
 import type { TypedData } from '../../../modules/ethereum/message-signing/TypedData';
 import { getGas } from '../../../modules/ethereum/transactions/getGas';
 
@@ -113,7 +114,7 @@ export function interpretSignature(
       chain,
       currency,
       domain: origin,
-      signature: { typedData },
+      signature: { typedData: sanitizeTypedData(typedData) },
     },
     { source }
   );


### PR DESCRIPTION
## Summary

A whitespace-padded `chainId` (e.g. `" 1"`) in an EIP-712 Permit domain is tolerated during signing — ethers coerces the domain `chainId` with `BigInt()`, which trims whitespace — but the raw value was forwarded to the interpretation backend, where it broke simulation. As a result the structured Permit UI and malicious-spender detection were skipped while the produced signature stayed valid and identical to the well-formed request (see the security report in the Linear issue).

- `sanitizeTypedData` (new, in `prepareTypedData.ts`): trims a whitespace-padded string `domain.chainId`; well-formed payloads are returned unchanged (byte-identical request for the normal case).
- `interpretSignature` now sends the sanitized typed data, covering both call sites (SignTypedData page and the paymaster interpretation path).
- `normalizeChainId` now trims string input before conversion — it previously threw on `" 1"`; trimming can't hurt any existing caller.

Closes WLT-1685

## Test plan

- Unit tests added: `prepareTypedData.test.ts` (trims padded chainId, no mutation of input, well-formed payloads returned as-is) and extended `normalizeChainId.test.ts` with padded inputs.
- Manual repro from the report: send `eth_signTypedData_v4` Permit with `chainId: 1` and `chainId: " 1"` — both should now show the structured Permit UI and run spender checks; signatures remain identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)