### PR TITLE
WLT-1723: bring back custom data in SendForm2

### DIFF
--- a/src/modules/zerion-api/requests/transaction-get-send.ts
+++ b/src/modules/zerion-api/requests/transaction-get-send.ts
@@ -21,6 +21,10 @@ export interface Params {
   amount?: string;
   /** @description Send maximum available amount */
   max?: boolean;
+  /** @description Optional arbitrary data attached to the transfer. A valid hex
+   * string (with or without `0x`) is used as raw bytes; otherwise the string is
+   * UTF-8 encoded. Lets users attach a message or calldata to a transfer. */
+  data?: string;
 }
 
 export interface Response {
@@ -56,6 +60,9 @@ export async function transactionGetSend(
     searchParams.set('max', 'true');
   } else if (params.amount != null) {
     searchParams.set('amount', params.amount);
+  }
+  if (params.data != null) {
+    searchParams.set('data', params.data);
   }
   const endpoint = `transaction/get-send/v1?${searchParams}`;
   return ZerionHttpClient.get<Response>(

--- a/src/ui/pages/SendForm2/SendDetails/SendDataLine.tsx
+++ b/src/ui/pages/SendForm2/SendDetails/SendDataLine.tsx
@@ -1,0 +1,98 @@
+import React, { useEffect, useState } from 'react';
+import { HStack } from 'src/ui/ui-kit/HStack';
+import { VStack } from 'src/ui/ui-kit/VStack';
+import { UIText } from 'src/ui/ui-kit/UIText';
+import { UnstyledButton } from 'src/ui/ui-kit/UnstyledButton';
+import { Button } from 'src/ui/ui-kit/Button';
+import { Dialog2, useDialog2 } from 'src/ui/ui-kit/ModalDialogs/Dialog2';
+import { noValueDash } from 'src/ui/shared/typography';
+import ChevronRightIcon from 'jsx:src/ui/assets/chevron-right.svg';
+import * as styles from './SendDetails.module.css';
+
+/** First 5 characters of the stored value, with an ellipsis when truncated. */
+function truncateData(value: string): string {
+  return value.length > 5 ? `${value.slice(0, 5)}…` : value;
+}
+
+export function SendDataLine({
+  value,
+  onChange,
+}: {
+  value: string | null;
+  onChange: (value: string | undefined) => void;
+}) {
+  const dialog = useDialog2();
+  const [draft, setDraft] = useState(value ?? '');
+
+  // Start the editor from the persisted value each time it opens, discarding
+  // any edits left over from a previous (closed-without-save) session.
+  useEffect(() => {
+    if (dialog.open) {
+      setDraft(value ?? '');
+    }
+  }, [dialog.open, value]);
+
+  return (
+    <>
+      <UnstyledButton
+        type="button"
+        className={styles.detailLinkRow}
+        onClick={dialog.openDialog}
+      >
+        <HStack gap={8} justifyContent="space-between" alignItems="center">
+          <UIText kind="small/regular">Data</UIText>
+          <HStack gap={4} alignItems="center">
+            <UIText kind="small/accent">
+              {value ? truncateData(value) : noValueDash}
+            </UIText>
+            <ChevronRightIcon className={styles.detailLinkChevron} />
+          </HStack>
+        </HStack>
+      </UnstyledButton>
+      <Dialog2
+        open={dialog.open}
+        onClose={dialog.closeDialog}
+        title="Data"
+        size="content"
+      >
+        <form
+          style={{ padding: 16, paddingTop: 0 }}
+          onSubmit={(event) => {
+            event.preventDefault();
+            onChange(draft ? draft : undefined);
+            dialog.closeDialog();
+          }}
+        >
+          <VStack gap={16}>
+            <UIText kind="small/accent" color="var(--neutral-600)">
+              Advanced Feature: Use with Caution
+            </UIText>
+            <textarea
+              name="data"
+              value={draft}
+              onChange={(event) => setDraft(event.currentTarget.value)}
+              className={styles.dataInput}
+              rows={3}
+              placeholder="0x..."
+              spellCheck={false}
+              autoComplete="off"
+            />
+            <HStack gap={8} style={{ gridTemplateColumns: '1fr 1fr' }}>
+              <Button
+                kind="regular"
+                type="button"
+                onClick={() => {
+                  onChange(undefined);
+                  dialog.closeDialog();
+                }}
+              >
+                Reset
+              </Button>
+              <Button kind="primary">Save</Button>
+            </HStack>
+          </VStack>
+        </form>
+      </Dialog2>
+    </>
+  );
+}

--- a/src/ui/pages/SendForm2/SendDetails/SendDetails.module.css
+++ b/src/ui/pages/SendForm2/SendDetails/SendDetails.module.css
@@ -53,3 +53,27 @@
 .detailLinkRow:hover .detailLinkChevron {
   color: var(--black);
 }
+
+.dataInput {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 12px;
+  border: 2px solid var(--neutral-200);
+  border-radius: 12px;
+  background-color: var(--white);
+  color: var(--black);
+  font-family: inherit;
+  font-size: 14px;
+  line-height: 20px;
+  resize: vertical;
+  outline: none;
+  transition: border-color 0.15s ease;
+}
+
+.dataInput:focus {
+  border-color: var(--primary);
+}
+
+.dataInput::placeholder {
+  color: var(--neutral-500);
+}

--- a/src/ui/pages/SendForm2/SendDetails/SendDetails.tsx
+++ b/src/ui/pages/SendForm2/SendDetails/SendDetails.tsx
@@ -33,6 +33,7 @@ import {
 } from 'src/ui/pages/SwapForm2/getNetworkFeeForSpeed';
 import ChevronRightIcon from 'jsx:src/ui/assets/chevron-right.svg';
 import type { SendQuote } from '../useSendTransaction';
+import { SendDataLine } from './SendDataLine';
 import * as styles from './SendDetails.module.css';
 
 function DetailRow({
@@ -93,6 +94,8 @@ export function SendDetails({
   onConfigurationChange,
   userNonce,
   onNonceChange,
+  customData,
+  onCustomDataChange,
   isLoading,
   receivedAmount,
   typedAmount,
@@ -109,6 +112,8 @@ export function SendDetails({
   onConfigurationChange: (configuration: CustomConfiguration) => void;
   userNonce: string | null;
   onNonceChange: (nonce: string | null) => void;
+  customData: string | null;
+  onCustomDataChange: (value: string | undefined) => void;
   isLoading: boolean;
   receivedAmount?: Amount | null;
   typedAmount?: string | null;
@@ -124,6 +129,12 @@ export function SendDetails({
   const customDefaults = getCustomFormDefaults(sendQuote);
   const showNonce = Boolean(
     preferences?.configurableNonce && isEthereumAddress(address)
+  );
+  // Custom data: gated behind the Developer Tools "Custom Data" toggle, EVM
+  // senders only. Shown for any EVM send (native + ERC-20); the backend owns
+  // how it attaches the data to the built transaction.
+  const showData = Boolean(
+    preferences?.configurableTransactionData && isEthereumAddress(address)
   );
 
   const chain = createChain(inputChain);
@@ -241,6 +252,12 @@ export function SendDetails({
                             <DetailRow label="Nonce" value={noValueDash} />
                           )}
                         </React.Suspense>
+                      ) : null}
+                      {showData ? (
+                        <SendDataLine
+                          value={customData}
+                          onChange={onCustomDataChange}
+                        />
                       ) : null}
                       <DetailRow
                         label="Network"

--- a/src/ui/pages/SendForm2/SendForm2.tsx
+++ b/src/ui/pages/SendForm2/SendForm2.tsx
@@ -652,6 +652,8 @@ function SendFormComponent({
               onNonceChange={(nonce) =>
                 handleChange('nonce', nonce ?? undefined)
               }
+              customData={formState.data ?? null}
+              onCustomDataChange={(value) => handleChange('data', value)}
               isLoading={sendDataLoading}
               receivedAmount={sendInputAmount}
               typedAmount={resolvedInputAmount}

--- a/src/ui/pages/SendForm2/shared/hexlifyTransactionData.ts
+++ b/src/ui/pages/SendForm2/shared/hexlifyTransactionData.ts
@@ -1,0 +1,11 @@
+import { hexlify, isHexString, toUtf8Bytes } from 'ethers';
+
+/**
+ * Normalize user-entered transaction data to a hex string for the backend.
+ * A `0x`-prefixed hex string is passed through unchanged (used as raw bytes);
+ * anything else is treated as a UTF-8 message and encoded to hex. Mirrors the
+ * wallet's message-signing convention (`hexlify(toUtf8Bytes(...))`).
+ */
+export function hexlifyTransactionData(value: string): string {
+  return isHexString(value) ? value : hexlify(toUtf8Bytes(value));
+}

--- a/src/ui/pages/SendForm2/useSendTransaction.ts
+++ b/src/ui/pages/SendForm2/useSendTransaction.ts
@@ -4,6 +4,8 @@ import BigNumber from 'bignumber.js';
 import { useMemo } from 'react';
 import { useDefiSdkClient } from 'src/modules/defi-sdk/useDefiSdkClient';
 import { useCurrency } from 'src/modules/currency/useCurrency';
+import { isEthereumAddress } from 'src/shared/isEthereumAddress';
+import { usePreferences } from 'src/ui/features/preferences/usePreferences';
 import { useHttpClientSource } from 'src/modules/zerion-api/hooks/useHttpClientSource';
 import { useTransactionGetSend } from 'src/modules/zerion-api/hooks/useTransactionGetSend';
 import type { FungiblePosition } from 'src/modules/zerion-api/requests/wallet-get-simple-positions';
@@ -22,6 +24,7 @@ import { valueToHex } from 'src/shared/units/valueToHex';
 import { prepareSendData } from 'src/ui/pages/SendForm/shared/prepareSendData';
 import { fungiblePositionToAddressPosition } from './shared/fungiblePositionToAddressPosition';
 import { toLegacySendFormState } from './shared/toLegacySendFormState';
+import { hexlifyTransactionData } from './shared/hexlifyTransactionData';
 import type { SendFormState2 } from './types';
 
 /**
@@ -118,8 +121,26 @@ export function useSendTransaction({
   const client = useDefiSdkClient();
   const { currency } = useCurrency();
   const source = useHttpClientSource();
+  const { preferences } = usePreferences();
 
   const isNftMode = Boolean(formState.nftId);
+
+  // Custom transaction data — gated behind the Developer Tools "Custom Data"
+  // toggle and EVM senders only. Stored raw (as typed) in the URL form state so
+  // the editor round-trips; hexlified here at the backend boundary so the API
+  // (and the local prep path) always receive a valid hex string. Fed to the
+  // backend `get-send` `data` param and injected into the local prep path so
+  // both send routes carry it identically.
+  const customData = useMemo(() => {
+    if (
+      !preferences?.configurableTransactionData ||
+      !isEthereumAddress(address) ||
+      !formState.data
+    ) {
+      return undefined;
+    }
+    return hexlifyTransactionData(formState.data);
+  }, [preferences?.configurableTransactionData, address, formState.data]);
 
   const isMax = useMemo(() => {
     if (isNftMode || !resolvedInputAmount || !position) return false;
@@ -156,6 +177,7 @@ export function useSendTransaction({
       assetId: assetId ?? '',
       amount: isMax ? undefined : effectiveAmount ?? undefined,
       max: isMax ? true : undefined,
+      data: customData,
     },
     { source },
     {
@@ -174,7 +196,9 @@ export function useSendTransaction({
 
   // Gas overrides are applied at sign time (via applyConfiguration), not in the
   // prep query — strip them here so the local path stays gas-unapplied and
-  // matches the backend path's shape.
+  // matches the backend path's shape. `data` is replaced with the gated,
+  // hexlified value so the local `prepareSendData` merge stays consistent with
+  // the backend param (and never carries a raw, non-hex string).
   const legacyFormState = useMemo(() => {
     const base = toLegacySendFormState(formState, resolvedInputAmount);
     return {
@@ -185,8 +209,9 @@ export function useSendTransaction({
       gasPrice: undefined,
       gasLimit: undefined,
       nonce: undefined,
+      data: customData,
     };
-  }, [formState, resolvedInputAmount]);
+  }, [formState, resolvedInputAmount, customData]);
 
   const localEnabled =
     enabledParam && baseGatesPass && !useBackend && Boolean(addressPosition);

--- a/src/ui/pages/Settings/Settings.tsx
+++ b/src/ui/pages/Settings/Settings.tsx
@@ -455,6 +455,16 @@ function DeveloperTools() {
             }
           />
           <ToggleSettingLine
+            text="Custom Data"
+            checked={preferences?.configurableTransactionData ?? false}
+            onChange={(event) => {
+              setPreferences({
+                configurableTransactionData: event.target.checked,
+              });
+            }}
+            detailText={<span>Attach arbitrary data to Send transactions</span>}
+          />
+          <ToggleSettingLine
             text="Recognizable Connect Buttons"
             checked={globalPreferences?.recognizableConnectButtons || false}
             onChange={(event) => {


### PR DESCRIPTION
## Summary

Restores the "Custom Data" capability in SendForm2 (its Developer Tools toggle was removed in #948), this time driven through the backend send endpoint instead of a client-side tx merge.

- **Settings → Developer Tools:** re-add the `configurableTransactionData` toggle ("Custom Data"). The preference field still exists in the wallet record (default `false`); only its UI was removed in #948.
- **`transaction-get-send`:** add the optional `data` request param.
- **`useSendTransaction`:** gate on `configurableTransactionData` + EVM sender, hexlify `formState.data` (`isHexString(v) ? v : hexlify(toUtf8Bytes(v))` — the codebase's message-signing convention) and pass it to the backend `get-send` `data` param, and inject the same hexlified value into the local (non-backend) prep path so both send routes carry it identically.
- **`SendDetails`:** add a "Data" row in the quote-details panel showing the first 5 chars of the value (`0x123…`, `—` when empty). Clicking opens a `Dialog2` textarea with **Save** (commit; empty clears) and **Reset** (clear & close). Mirrors `NonceLine2`.
- **URL state:** `formState.data` already existed in `SendFormState2` — URL-persisted, cleared after broadcast, and in the sim/sign reset deps. Reused as-is; the value is stored **raw** (as typed) so the editor round-trips, and hexlified only at the backend boundary.

Scope: all EVM sends (native + ERC-20) when the toggle is on and the sender is an EVM address. The backend owns how it attaches `data` to the built transaction. Solana and input validation are out of scope (matches the old form).

## Test plan

- Enable **Settings → Developer Tools → Custom Data**.
- Open Send, pick an EVM asset + recipient + amount, expand **Details** → a **Data** row appears.
- Click it → dialog with a textarea. Type `0xdeadbeef`, **Save** → row shows `0xdea…`; URL carries `data`. Reopen the details/sign flow and confirm the prepared transaction's `data` is `0xdeadbeef`.
- Type plain text `gm frens`, **Save** → backend receives the UTF-8→hex value (`0x676d206672656e73`).
- **Reset** in the dialog clears the value (row → `—`, `data` removed from URL).
- Disable the toggle → the Data row disappears and no `data` param is sent.
- Non-EVM (Solana) send: no Data row, no `data` param.

Closes WLT-1723

🤖 Generated with [Claude Code](https://claude.com/claude-code)