### PR TITLE
WLT-1724: fix history filtering for local txs

### DIFF
--- a/src/background/transactions/TransactionService.ts
+++ b/src/background/transactions/TransactionService.ts
@@ -220,7 +220,7 @@ export class TransactionService {
 
     for (const item of transactions) {
       if (!item.hash) {
-        return; // Do not handle Solana items
+        continue; // Do not handle Solana items
       }
       const chainId = normalizeChainId(item.transaction.chainId);
       const key = `${item.transaction.from}:${chainId}` as const;

--- a/src/ui/pages/History/History.tsx
+++ b/src/ui/pages/History/History.tsx
@@ -53,8 +53,7 @@ function sortActions<T extends { timestamp?: number }>(actions: T[]) {
 
 function mergeLocalAndBackendActions(
   local: AnyAddressAction[],
-  backend: AddressAction[],
-  hasMoreBackendActions: boolean
+  backend: AddressAction[]
 ) {
   const backendHashes = new Set(
     backend.flatMap(
@@ -63,11 +62,13 @@ function mergeLocalAndBackendActions(
     )
   );
 
-  const lastBackendActionDatetime = backend.at(-1)?.timestamp;
-  const lastBackendTimestamp =
-    lastBackendActionDatetime && hasMoreBackendActions
-      ? new Date(lastBackendActionDatetime).getTime()
-      : 0;
+  // Backend actions are sorted newest-first. A mined local action that is
+  // older than the newest backend action already belongs to the backend
+  // history, so rendering it would duplicate the backend entry even when the
+  // hashes don't match (e.g. replaced or accelerated transactions). Pending
+  // actions are kept regardless: they aren't indexed yet, and hiding them
+  // would remove the entry point for speeding up or cancelling them.
+  const newestBackendTimestamp = backend.at(0)?.timestamp ?? 0;
 
   const merged = local
     .filter(
@@ -78,7 +79,7 @@ function mergeLocalAndBackendActions(
           (act) =>
             act.transaction.hash && backendHashes.has(act.transaction.hash)
         ) &&
-        tx.timestamp >= lastBackendTimestamp
+        (tx.status === 'pending' || tx.timestamp > newestBackendTimestamp)
     )
     .concat(backend);
   return sortActions(merged);
@@ -157,6 +158,14 @@ function useMinedAndPendingAddressActions({
       }
       if (assetTypes?.length === 1 && assetTypes?.[0] === 'nft') {
         items = items.filter(() => false);
+      } else if (assetTypes?.length === 1 && assetTypes?.[0] === 'fungible') {
+        items = items.filter((item) =>
+          [item.content, ...(item.acts?.map((act) => act.content) ?? [])].some(
+            (content) =>
+              content?.transfers?.some((transfer) => transfer.fungible) ||
+              content?.approvals?.some((approval) => approval.fungible)
+          )
+        );
       }
       return items;
     },
@@ -180,14 +189,9 @@ function useMinedAndPendingAddressActions({
 
   return useMemo(() => {
     const backendItems = isSupportedByBackend && actions ? actions : [];
-    const hasMore = Boolean(isSupportedByBackend && queryData.hasNextPage);
     return {
       actions: localAddressActions
-        ? mergeLocalAndBackendActions(
-            localAddressActions,
-            backendItems,
-            hasMore
-          )
+        ? mergeLocalAndBackendActions(localAddressActions, backendItems)
         : null,
       ...localActionsQuery,
       isLoading:


### PR DESCRIPTION
## Summary

Local (client-stored) transactions were leaking into the filtered transaction history, showing duplicated rows next to their backend twins and inflating traded volume (~2×). Root cause and decisions are documented in a PRD comment on the Linear issue.

- **`mergeLocalAndBackendActions` guard rewritten** (`src/ui/pages/History/History.tsx`): previously local actions were kept when newer than the *oldest loaded* backend action (threshold 0 when there was no next page), which the unfiltered view masked but filtered views exposed. Now a mined local action is shown only while it is *strictly newer than the newest backend action* — i.e. only while it bridges the backend indexing gap — matching Web. Pending local actions bypass the timestamp guard so stuck transactions stay reachable for Speed Up / Cancel; hash dedup remains as a second layer.
- **`performPurgeCheck` loop fix** (`src/background/transactions/TransactionService.ts`): `return` → `continue` — a single Solana item in the store aborted the whole purge run, so mined EVM transactions accumulated locally forever, feeding the leak.
- **Local `assetTypes=fungible` filter gap**: local actions are now required to contain a fungible transfer/approval when the fungible asset filter is active (the `nft` case already excluded all local items).

Closes WLT-1724

## Test plan

- `npm run type-check`, `npm run lint`, prettier — all pass
- Manual: with stale mined/dropped local txs in the store, open History with an action-type or asset-type filter → no duplicated trades, totals match the unfiltered view and Web
- Manual: send a transaction → it appears as pending in History (with and without matching filters) and stays visible while pending; after mining it is replaced by the backend entry once indexed

🤖 Generated with [Claude Code](https://claude.com/claude-code)