### PR TITLE
WLT-1757: remove Wallet from DeFi distribution and rename section

### DIFF
--- a/src/ui/pages/Overview/DistributionCharts/ProtocolDistributionChart.tsx
+++ b/src/ui/pages/Overview/DistributionCharts/ProtocolDistributionChart.tsx
@@ -1,14 +1,10 @@
 import React, { useMemo, useState } from 'react';
-import WalletIcon from 'jsx:src/ui/assets/wallet-fancy.svg';
 import PieChartIcon from 'jsx:src/ui/assets/pie-chart.svg';
 import { useCurrency } from 'src/modules/currency/useCurrency';
 import { useHttpClientSource } from 'src/modules/zerion-api/hooks/useHttpClientSource';
 import { useHttpAddressPositions } from 'src/modules/zerion-api/hooks/useWalletPositions';
 import { groupPositionsByDapp } from 'src/ui/components/Positions/groupPositions';
-import {
-  DEFAULT_PROTOCOL_ID,
-  DEFAULT_PROTOCOL_NAME,
-} from 'src/ui/components/Positions/types';
+import { DEFAULT_PROTOCOL_ID } from 'src/ui/components/Positions/types';
 import {
   DistributionChart,
   type DistributionItem,
@@ -17,10 +13,13 @@ import { PositionsListDialog } from './PositionsListDialog';
 import { DistributionItemTitle } from './DistributionItemTitle';
 
 /**
- * Protocol allocation on the Stats tab. Backend positions carry `dapp`, so we
- * group by `dapp.id` (the no-dapp bucket is `wallet` / "Wallet"). Each group is
- * summed **gross** — loans are added, not subtracted — so every tile area is
- * positive (diverging from the positions view's net `getFullPositionsValue`).
+ * DeFi protocol allocation on the Stats tab. Backend positions carry `dapp`, so
+ * we group by `dapp.id` and drop the synthetic no-dapp bucket (`wallet`) — plain
+ * token holdings aren't a protocol, so the chart reflects DeFi allocation only,
+ * with the remaining protocols re-normalized to 100% by the shared chart. Each
+ * group is summed **gross** — loans are added, not subtracted — so every tile
+ * area is positive (diverging from the positions view's net
+ * `getFullPositionsValue`).
  */
 export function ProtocolDistributionChart({ address }: { address: string }) {
   const { currency } = useCurrency();
@@ -37,23 +36,25 @@ export function ProtocolDistributionChart({ address }: { address: string }) {
       return [];
     }
     const groups = groupPositionsByDapp(positions);
-    return Object.entries(groups).map(([dappId, groupPositions]) => {
-      const value = groupPositions.reduce(
-        (sum, position) => sum + (Number(position.value) || 0),
-        0
-      );
-      const isWallet = dappId === DEFAULT_PROTOCOL_ID;
-      const dapp = groupPositions.find((position) => position.dapp)?.dapp;
-      return {
-        id: dappId,
-        label: isWallet ? DEFAULT_PROTOCOL_NAME : dapp?.name ?? dappId,
-        value,
-        iconUrl: isWallet ? null : dapp?.icon_url ?? null,
-        iconNode: isWallet ? (
-          <WalletIcon style={{ width: 24, height: 24 }} />
-        ) : undefined,
-      };
-    });
+    return (
+      Object.entries(groups)
+        // Exclude the synthetic "Wallet" bucket (positions not in any dapp) so the
+        // chart reflects DeFi protocol allocation only.
+        .filter(([dappId]) => dappId !== DEFAULT_PROTOCOL_ID)
+        .map(([dappId, groupPositions]) => {
+          const value = groupPositions.reduce(
+            (sum, position) => sum + (Number(position.value) || 0),
+            0
+          );
+          const dapp = groupPositions.find((position) => position.dapp)?.dapp;
+          return {
+            id: dappId,
+            label: dapp?.name ?? dappId,
+            value,
+            iconUrl: dapp?.icon_url ?? null,
+          };
+        })
+    );
   }, [data]);
 
   const [selected, setSelected] = useState<DistributionItem | null>(null);
@@ -61,7 +62,7 @@ export function ProtocolDistributionChart({ address }: { address: string }) {
   return (
     <>
       <DistributionChart
-        title="Protocol Distribution"
+        title="DeFi Distribution"
         titleIcon={<PieChartIcon style={{ width: 24, height: 24 }} />}
         items={items}
         currency={currency}


### PR DESCRIPTION
## Summary

On the Stats tab, the **"Protocol Distribution"** treemap bucketed plain token holdings under a synthetic **"Wallet"** tile that typically dominated the chart (e.g. 84%), drowning out actual DeFi protocols.

- Filter out the synthetic `wallet` bucket in `ProtocolDistributionChart` so the chart reflects **DeFi protocol allocation only**. The shared `DistributionChart` derives its total from the items passed in, so the remaining protocols **re-normalize to 100% automatically**.
- Rename the section to **"DeFi Distribution"** — parallel to the sibling **"Network Distribution"** on the same tab.
- Remove the now-dead wallet branch, `WalletIcon` import, and `DEFAULT_PROTOCOL_NAME` import from this file (both remain used elsewhere).

Scope is limited to `ProtocolDistributionChart.tsx`. The shared chart, its `MIN_TILES` gate, the sibling network chart, `groupPositionsByDapp`, the positions list, and the `DEFAULT_PROTOCOL_ID/NAME` constants are untouched.

### Behavior note
Without the dominant Wallet tile, wallets with fewer than 3 DeFi protocols fall below the chart's existing `MIN_TILES = 3` render gate, so the **"DeFi Distribution" section simply doesn't appear** for them. This is intentional and consistent with how the chart already handles sparse data — no new empty-state UI (confirmed during scoping).

Closes WLT-1757

## Test plan
- [ ] Stats tab: the section is titled **"DeFi Distribution"** and no longer shows a "Wallet" tile.
- [ ] Remaining DeFi protocol percentages sum to ~100% (re-normalized without Wallet).
- [ ] Clicking a protocol tile still opens the positions drill-in dialog for that protocol.
- [ ] A wallet with 0–2 DeFi protocols: the section is hidden (no empty state, no crash).
- [ ] Sibling **"Network Distribution"** section and the Positions view are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)