### PR TITLE
WLT-1759: allow Zerion RPC for direct requests from whitelisted dapps

### DIFF
--- a/src/background/messaging/port-message-handlers/createHTTPConnectionMessageHandler.ts
+++ b/src/background/messaging/port-message-handlers/createHTTPConnectionMessageHandler.ts
@@ -11,6 +11,7 @@ import {
 } from 'src/shared/custom-rpc';
 import { normalizeChainId } from 'src/shared/normalizeChainId';
 import { invariant } from 'src/shared/invariant';
+import { isWhitelistedForZerionRpc } from 'src/shared/dapps/zerion-rpc-whitelist';
 import { getPortContext } from '../getPortContext';
 import { HttpConnection } from '../HttpConnection';
 import type { PortMessageHandler } from '../PortRegistry';
@@ -31,7 +32,10 @@ export function createHttpConnectionMessageHandler(
           .eth_chainId({ context, id: msg.id })
           .then((chainIdStr) => {
             const chainId = normalizeChainId(chainIdStr);
-            return wallet.getRpcUrlByChainId({ chainId, type: 'public' });
+            const type = isWhitelistedForZerionRpc(context.origin)
+              ? 'internal'
+              : 'public';
+            return wallet.getRpcUrlByChainId({ chainId, type });
           })
           .then((url) => {
             invariant(url, `HttpConnection: No RpcUrl for ${context.origin}`);

--- a/src/shared/dapps/zerion-rpc-whitelist.test.ts
+++ b/src/shared/dapps/zerion-rpc-whitelist.test.ts
@@ -1,0 +1,14 @@
+import { isWhitelistedForZerionRpc } from './zerion-rpc-whitelist';
+
+test('isWhitelistedForZerionRpc', () => {
+  expect(isWhitelistedForZerionRpc('https://safe.global')).toBe(true);
+  expect(isWhitelistedForZerionRpc('https://app.safe.global')).toBe(true);
+
+  expect(isWhitelistedForZerionRpc('https://app.uniswap.org')).toBe(false);
+  expect(isWhitelistedForZerionRpc('https://notsafe.global')).toBe(false);
+  expect(isWhitelistedForZerionRpc('https://safe.global.evil.com')).toBe(false);
+
+  expect(isWhitelistedForZerionRpc(undefined)).toBe(false);
+  expect(isWhitelistedForZerionRpc('')).toBe(false);
+  expect(isWhitelistedForZerionRpc('not-a-url')).toBe(false);
+});

--- a/src/shared/dapps/zerion-rpc-whitelist.ts
+++ b/src/shared/dapps/zerion-rpc-whitelist.ts
@@ -1,0 +1,22 @@
+/**
+ * Dapps whose direct RPC requests (eth_call and other passthrough methods)
+ * are sent to Zerion RPC instead of public RPC urls, because public urls
+ * may rate-limit (429) and break the dapp. Entries are registrable domains;
+ * subdomains match, e.g. 'safe.global' matches 'app.safe.global'.
+ */
+const WHITELISTED_DAPP_DOMAINS = ['safe.global'];
+
+export function isWhitelistedForZerionRpc(origin: string | undefined) {
+  if (!origin) {
+    return false;
+  }
+  let hostname: string;
+  try {
+    hostname = new URL(origin).hostname;
+  } catch {
+    return false;
+  }
+  return WHITELISTED_DAPP_DOMAINS.some(
+    (domain) => hostname === domain || hostname.endsWith(`.${domain}`)
+  );
+}


### PR DESCRIPTION
## Summary

Dapp-originated passthrough RPC calls (e.g. `eth_call`) are forwarded to public RPC URLs, which sometimes rate-limit (429) and break the dapp. This PR routes those calls to Zerion's internal RPC for a hard-coded whitelist of trusted dapps, currently containing `safe.global`.

- New `src/shared/dapps/zerion-rpc-whitelist.ts`: hard-coded domain whitelist with subdomain-inclusive matching (`safe.global` matches `app.safe.global`, but not `notsafe.global` or `safe.global.evil.com`), plus a unit test.
- `createHTTPConnectionMessageHandler`: the dapp (`/ethereum` port) branch now resolves the RPC URL with `type: 'internal'` when the port origin is whitelisted, `'public'` otherwise. The existing `internal` resolution keeps user-defined RPC overrides first and falls back to public when a chain has no internal URL. The `http-connection-ui` branch is untouched.

Closes WLT-1759

## Test plan

- `npx jest src/shared/dapps/zerion-rpc-whitelist.test.ts` — matching semantics incl. subdomains, lookalike domains, undefined/invalid origins.
- `npm run type-check`, `npm run lint` — clean.
- Manual: connect the wallet on app.safe.global and confirm passthrough calls (eth_call, eth_getBalance) hit the Zerion RPC URL in the background service-worker network log; confirm an arbitrary other dapp still uses the public RPC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)