### PR TITLE
WLT-1720: allow selecting tokens not held in wallet in swap input picker

### DIFF
--- a/src/modules/zerion-api/hooks/useSearchQueryFungibles.ts
+++ b/src/modules/zerion-api/hooks/useSearchQueryFungibles.ts
@@ -5,15 +5,13 @@ import type { Response } from 'src/modules/zerion-api/requests/search-query-fung
 import { isTruthy } from 'is-truthy-ts';
 import type { Params } from '../requests/search-query-fungibles';
 
-export function useSearchQueryFungibles({
-  query,
-  currency,
-  chain,
-  sort,
-  limit = 5,
-}: Params) {
+export function useSearchQueryFungibles(
+  { query, currency, chain, sort, limit = 5 }: Params,
+  { enabled = true }: { enabled?: boolean } = {}
+) {
   const queryData = useInfiniteQuery<Response | null>({
     queryKey: ['searchQueryFungibles', query, currency, chain, limit, sort],
+    enabled,
     queryFn: ({ pageParam }) => {
       return ZerionAPI.searchQueryFungibles({
         query,

--- a/src/ui/components/PositionSelector/TokenListSkeleton.tsx
+++ b/src/ui/components/PositionSelector/TokenListSkeleton.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import * as styles from './styles.module.css';
+
+export function TokenListSkeleton({ count }: { count: number }) {
+  return (
+    <>
+      {Array.from({ length: count }).map((_, i) => (
+        <div key={i} className={styles.skeletonRow}>
+          <div className={styles.skeletonIcon} />
+          <div className={styles.skeletonInfo}>
+            <div className={styles.skeletonLineLg} />
+            <div className={styles.skeletonLineSm} />
+          </div>
+          <div className={styles.skeletonValues}>
+            <div className={styles.skeletonValueLg} />
+            <div className={styles.skeletonValueSm} />
+          </div>
+        </div>
+      ))}
+    </>
+  );
+}

--- a/src/ui/pages/SwapForm2/InputPosition.tsx
+++ b/src/ui/pages/SwapForm2/InputPosition.tsx
@@ -320,8 +320,8 @@ export function InputPosition({
         positions={positions}
         networks={networks}
         defaultSelectedTab={lastSelectedTab}
-        onSelect={(selected, selectedTab) => {
-          onSelectFungible(selected.chain.id, selected.fungible.id);
+        onSelect={(chainId, fungibleId, selectedTab) => {
+          onSelectFungible(chainId, fungibleId);
           setLastSelectedTab(selectedTab);
         }}
       />

--- a/src/ui/pages/SwapForm2/PositionSelector/InputPositionSelector.tsx
+++ b/src/ui/pages/SwapForm2/PositionSelector/InputPositionSelector.tsx
@@ -113,6 +113,25 @@ function heldRow(position: FungiblePosition): RowItem {
 }
 
 /**
+ * Matches a fungible by contract address on any of its implementation chains,
+ * so that pasting an address surfaces held rows and not only the backend
+ * search results (which match addresses across all chains). Skipped for short
+ * queries: single hex chars occur in almost every address and would defeat
+ * the name/symbol filter.
+ */
+function matchesAddressQuery(fungible: Fungible, query: string): boolean {
+  if (query.length < 4) {
+    return false;
+  }
+  return (
+    fungible.id.toLowerCase().includes(query) ||
+    Object.values(fungible.implementations).some((impl) =>
+      impl.address ? impl.address.toLowerCase().includes(query) : false
+    )
+  );
+}
+
+/**
  * Orders a fungible's implementation chains so the ones already surfaced as
  * network chips come first (in chip order), then the rest in backend order.
  */
@@ -267,7 +286,8 @@ export function InputPositionSelector({
       result = result.filter(
         (p) =>
           normalizedContains(p.fungible.name.toLowerCase(), query) ||
-          normalizedContains(p.fungible.symbol.toLowerCase(), query)
+          normalizedContains(p.fungible.symbol.toLowerCase(), query) ||
+          matchesAddressQuery(p.fungible, query)
       );
     }
     return result.sort((a, b) => (b.amount.value || 0) - (a.amount.value || 0));

--- a/src/ui/pages/SwapForm2/PositionSelector/InputPositionSelector.tsx
+++ b/src/ui/pages/SwapForm2/PositionSelector/InputPositionSelector.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {
   ComboboxProvider,
   Combobox,
@@ -10,11 +16,14 @@ import SearchIcon from 'jsx:src/ui/assets/search.svg';
 import type { Networks } from 'src/modules/networks/Networks';
 import { createChain } from 'src/modules/networks/Chain';
 import type { FungiblePosition } from 'src/modules/zerion-api/requests/wallet-get-simple-positions';
+import type { Fungible } from 'src/modules/zerion-api/types/Fungible';
 import { UIText } from 'src/ui/ui-kit/UIText';
 import { KeyboardShortcut } from 'src/ui/components/KeyboardShortcut';
 import { useCurrency } from 'src/modules/currency/useCurrency';
+import { useSearchQueryFungibles } from 'src/modules/zerion-api/hooks/useSearchQueryFungibles';
 import { Dialog2 } from 'src/ui/ui-kit/ModalDialogs/Dialog2';
 import { Input } from 'src/ui/ui-kit/Input';
+import { useDebouncedCallback } from 'src/ui/shared/useDebouncedCallback';
 import { useDialog2 } from 'src/ui/ui-kit/ModalDialogs/Dialog2';
 import {
   ALL_NETWORKS_TAB_ID,
@@ -22,6 +31,7 @@ import {
   TabPanelWrapper,
 } from 'src/ui/components/PositionSelector/NetworkChips';
 import { TokenRow } from 'src/ui/components/PositionSelector/TokenRow';
+import { TokenListSkeleton } from 'src/ui/components/PositionSelector/TokenListSkeleton';
 import { useTopNetworks } from 'src/ui/components/PositionSelector/useTopNetworks';
 import type { VirtualListItem } from 'src/ui/components/PositionSelector/VirtualizedTokenList';
 import { VirtualizedTokenList } from 'src/ui/components/PositionSelector/VirtualizedTokenList';
@@ -68,6 +78,74 @@ const SearchCombobox = React.forwardRef<HTMLInputElement>(
   }
 );
 
+/** A single list row, unifying held positions and searched (not-held) tokens. */
+type RowItem = {
+  fungible: Fungible;
+  chainId: string;
+  chainIconUrl: string;
+  chainName: string;
+  /** Fiat value / token quantity are only known for held positions. */
+  fiatValue: number | null;
+  tokenQuantity: string | null;
+};
+
+function positionKey(chainId: string, fungibleId: string): string {
+  return `${chainId}|${fungibleId}`;
+}
+
+function resolveChain(networks: Networks, chainId: string) {
+  const network = networks.getByNetworkId(createChain(chainId));
+  return {
+    chainIconUrl: network?.icon_url ?? '',
+    chainName: network?.name ?? '',
+  };
+}
+
+function heldRow(position: FungiblePosition): RowItem {
+  return {
+    fungible: position.fungible,
+    chainId: position.chain.id,
+    chainIconUrl: position.chain.iconUrl,
+    chainName: position.chain.name,
+    fiatValue: position.amount.value,
+    tokenQuantity: position.amount.quantity,
+  };
+}
+
+/**
+ * Orders a fungible's implementation chains so the ones already surfaced as
+ * network chips come first (in chip order), then the rest in backend order.
+ */
+function orderImplementationChains(
+  implChains: string[],
+  chipOrder: string[]
+): string[] {
+  const remaining = new Set(implChains);
+  const ordered: string[] = [];
+  for (const chainId of chipOrder) {
+    if (remaining.has(chainId)) {
+      ordered.push(chainId);
+      remaining.delete(chainId);
+    }
+  }
+  for (const chainId of implChains) {
+    if (remaining.has(chainId)) {
+      ordered.push(chainId);
+      remaining.delete(chainId);
+    }
+  }
+  return ordered;
+}
+
+/**
+ * On top of holdings, a non-empty query also runs a backend token search
+ * (`useSearchQueryFungibles`, mirroring the Receive selector). Matching tokens
+ * the wallet does NOT hold are shown as zero-balance rows in a distinct
+ * "Tokens not held in wallet" group below the holdings, so users can pick any
+ * token (e.g. to simulate a swap). Each result expands into one row per
+ * tradable implementation chain; the selected network chip narrows both the
+ * holdings list and the search rows to that chain ("All" searches every chain).
+ */
 export function InputPositionSelector({
   positions,
   networks,
@@ -79,29 +157,31 @@ export function InputPositionSelector({
   positions: FungiblePosition[];
   networks: Networks | null;
   defaultSelectedTab?: string | null;
-  onSelect: (position: FungiblePosition, selectedTab: string | null) => void;
+  onSelect: (
+    chainId: string,
+    fungibleId: string,
+    selectedTab: string | null
+  ) => void;
   open: boolean;
   onClose: () => void;
 }) {
   const { currency } = useCurrency();
   const [searchValue, setSearchValue] = useState('');
+  const [debouncedQuery, setDebouncedQuery] = useState('');
 
-  const tradablePositions = useMemo(() => {
-    const resolvedNetworks = networks;
-    if (!resolvedNetworks) return positions;
-    const cache = new Map<string, boolean>();
-    const isTradable = (chainId: string) => {
-      const cached = cache.get(chainId);
-      if (cached !== undefined) return cached;
-      const network = resolvedNetworks.getByNetworkId(createChain(chainId));
-      const ok = Boolean(
-        network?.supports_trading || network?.supports_bridging
-      );
-      cache.set(chainId, ok);
-      return ok;
-    };
-    return positions.filter((p) => isTradable(p.chain.id));
-  }, [positions, networks]);
+  const isTradableChainId = useCallback(
+    (chainId: string) => {
+      if (!networks) return true;
+      const network = networks.getByNetworkId(createChain(chainId));
+      return Boolean(network?.supports_trading || network?.supports_bridging);
+    },
+    [networks]
+  );
+
+  const tradablePositions = useMemo(
+    () => positions.filter((p) => isTradableChainId(p.chain.id)),
+    [positions, isTradableChainId]
+  );
 
   const [selectedNetwork, setSelectedNetwork] = useState<string | null>(() => {
     const tabExists =
@@ -121,9 +201,17 @@ export function InputPositionSelector({
     el?.scrollIntoView({ block: 'nearest', inline: 'center' });
   };
 
+  const debouncedSetQuery = useDebouncedCallback(
+    useCallback((value: string) => setDebouncedQuery(value), []),
+    300
+  );
+
   useEffect(() => {
     if (!open) {
       setPinnedFromDialog(null);
+      setSearchValue('');
+      setDebouncedQuery('');
+      debouncedSetQuery.cancel();
       return;
     }
     requestAnimationFrame(() => {
@@ -137,6 +225,11 @@ export function InputPositionSelector({
     tradablePositions,
     selectedNetwork,
     pinnedFromDialog
+  );
+
+  const chipOrder = useMemo(
+    () => topNetworks.map((n) => n.chainId),
+    [topNetworks]
   );
 
   const showNetworkSelectorTrigger = topNetworks.length >= 4;
@@ -180,15 +273,90 @@ export function InputPositionSelector({
     return result.sort((a, b) => (b.amount.value || 0) - (a.amount.value || 0));
   }, [tradablePositions, selectedNetwork, searchValue]);
 
-  const virtualItems = useMemo<VirtualListItem<FungiblePosition>[]>(
+  const { fungibles: searchFungibles, queryData: searchQueryData } =
+    useSearchQueryFungibles(
+      { query: debouncedQuery, currency, limit: 50 },
+      { enabled: Boolean(debouncedQuery) }
+    );
+
+  // Held (chain, fungible) pairs are shown in the holdings group above, so they
+  // are dropped from the not-held search group to avoid duplicates.
+  const heldKeys = useMemo(
     () =>
-      filteredPositions.map((position) => ({
-        kind: 'item',
-        key: `${position.chain.id}-${position.fungible.id}`,
-        data: position,
-      })),
-    [filteredPositions]
+      new Set(
+        tradablePositions.map((p) => positionKey(p.chain.id, p.fungible.id))
+      ),
+    [tradablePositions]
   );
+
+  const notHeldRows = useMemo<RowItem[]>(() => {
+    if (!searchFungibles || !networks || !debouncedQuery) {
+      return [];
+    }
+    const seen = new Set<string>();
+    const rows: RowItem[] = [];
+    for (const fungible of searchFungibles) {
+      const candidateChains = selectedNetwork
+        ? fungible.implementations[selectedNetwork]
+          ? [selectedNetwork]
+          : []
+        : orderImplementationChains(
+            Object.keys(fungible.implementations),
+            chipOrder
+          );
+      for (const chainId of candidateChains) {
+        if (!isTradableChainId(chainId)) continue;
+        const key = positionKey(chainId, fungible.id);
+        if (heldKeys.has(key) || seen.has(key)) continue;
+        seen.add(key);
+        rows.push({
+          fungible,
+          chainId,
+          ...resolveChain(networks, chainId),
+          fiatValue: null,
+          tokenQuantity: null,
+        });
+      }
+    }
+    return rows;
+  }, [
+    searchFungibles,
+    networks,
+    debouncedQuery,
+    selectedNetwork,
+    chipOrder,
+    isTradableChainId,
+    heldKeys,
+  ]);
+
+  const virtualItems = useMemo<VirtualListItem<RowItem>[]>(() => {
+    const items: VirtualListItem<RowItem>[] = filteredPositions.map(
+      (position) => ({
+        kind: 'item',
+        key: `held-${position.chain.id}-${position.fungible.id}`,
+        data: heldRow(position),
+      })
+    );
+    if (notHeldRows.length > 0) {
+      items.push({
+        kind: 'header',
+        key: 'not-held',
+        label: 'Tokens not held in wallet',
+      });
+      for (const row of notHeldRows) {
+        items.push({
+          kind: 'item',
+          key: `search-${row.chainId}-${row.fungible.id}`,
+          data: row,
+        });
+      }
+    }
+    return items;
+  }, [filteredPositions, notHeldRows]);
+
+  // While the backend search is loading its first page, show a skeleton instead
+  // of the "no tokens found" empty state (holdings, if any, still render above).
+  const searchLoading = Boolean(debouncedQuery) && searchQueryData.isLoading;
 
   return (
     <>
@@ -214,7 +382,10 @@ export function InputPositionSelector({
             focusShift
             focusWrap="horizontal"
             resetValueOnHide
-            setValue={setSearchValue}
+            setValue={(value) => {
+              setSearchValue(value);
+              debouncedSetQuery(value);
+            }}
           >
             <TabProvider
               selectedId={selectedNetwork ?? ALL_NETWORKS_TAB_ID}
@@ -238,30 +409,54 @@ export function InputPositionSelector({
                 <div className={styles.scrollArea}>
                   <TabPanelWrapper>
                     {virtualItems.length === 0 ? (
-                      <div className={styles.emptyState}>
-                        <UIText kind="body/regular" color="var(--neutral-500)">
-                          No tokens found
-                        </UIText>
-                      </div>
+                      searchLoading ? (
+                        <TokenListSkeleton count={5} />
+                      ) : (
+                        <div className={styles.emptyState}>
+                          <UIText
+                            kind="body/regular"
+                            color="var(--neutral-500)"
+                          >
+                            No tokens found
+                          </UIText>
+                        </div>
+                      )
                     ) : (
-                      <VirtualizedTokenList
-                        items={virtualItems}
-                        renderItem={(position) => (
-                          <TokenRow
-                            fungible={position.fungible}
-                            chainId={position.chain.id}
-                            chainIconUrl={position.chain.iconUrl}
-                            chainName={position.chain.name}
-                            fiatValue={position.amount.value}
-                            tokenQuantity={position.amount.quantity}
-                            currency={currency}
-                            onSelect={() => {
-                              onSelect(position, selectedNetwork);
-                              onClose();
-                            }}
-                          />
-                        )}
-                      />
+                      <>
+                        <VirtualizedTokenList
+                          items={virtualItems}
+                          renderItem={(row) => (
+                            <TokenRow
+                              fungible={row.fungible}
+                              chainId={row.chainId}
+                              chainIconUrl={row.chainIconUrl}
+                              chainName={row.chainName}
+                              fiatValue={row.fiatValue}
+                              tokenQuantity={row.tokenQuantity}
+                              currency={currency}
+                              onSelect={() => {
+                                onSelect(
+                                  row.chainId,
+                                  row.fungible.id,
+                                  selectedNetwork
+                                );
+                                onClose();
+                              }}
+                            />
+                          )}
+                          renderHeader={(label) => (
+                            <div className={styles.sectionHeader}>
+                              <UIText
+                                kind="small/accent"
+                                color="var(--neutral-500)"
+                              >
+                                {label}
+                              </UIText>
+                            </div>
+                          )}
+                        />
+                        {searchLoading ? <TokenListSkeleton count={3} /> : null}
+                      </>
                     )}
                   </TabPanelWrapper>
                 </div>

--- a/src/ui/pages/SwapForm2/PositionSelector/OutputPositionSelector.tsx
+++ b/src/ui/pages/SwapForm2/PositionSelector/OutputPositionSelector.tsx
@@ -24,6 +24,7 @@ import {
   TabPanelWrapper,
 } from 'src/ui/components/PositionSelector/NetworkChips';
 import { TokenRow } from 'src/ui/components/PositionSelector/TokenRow';
+import { TokenListSkeleton } from 'src/ui/components/PositionSelector/TokenListSkeleton';
 import { useTopNetworks } from 'src/ui/components/PositionSelector/useTopNetworks';
 import type { TopNetworksEntry } from 'src/ui/components/PositionSelector/useTopNetworks';
 import type { VirtualListItem } from 'src/ui/components/PositionSelector/VirtualizedTokenList';
@@ -108,26 +109,6 @@ function resolveChain(networks: Networks, chainId: string) {
     chainIconUrl: network?.icon_url ?? '',
     chainName: network?.name ?? '',
   };
-}
-
-function TokenListSkeleton({ count }: { count: number }) {
-  return (
-    <>
-      {Array.from({ length: count }).map((_, i) => (
-        <div key={i} className={styles.skeletonRow}>
-          <div className={styles.skeletonIcon} />
-          <div className={styles.skeletonInfo}>
-            <div className={styles.skeletonLineLg} />
-            <div className={styles.skeletonLineSm} />
-          </div>
-          <div className={styles.skeletonValues}>
-            <div className={styles.skeletonValueLg} />
-            <div className={styles.skeletonValueSm} />
-          </div>
-        </div>
-      ))}
-    </>
-  );
 }
 
 function positionKey(chainId: string, fungibleId: string): string {


### PR DESCRIPTION
## Summary

The SwapForm2 Pay-with selector only listed tokens the wallet holds, so users couldn't pick a token they don't have (e.g. to simulate a swap, or when the holding wallet isn't connected). Now a non-empty search query also runs a backend token search (`useSearchQueryFungibles`, same hook the Receive selector uses, debounced 300ms) and shows matches the wallet does **not** hold as zero-balance rows in a "Tokens not held in wallet" section below the holdings.

Mirrors the web-app implementation (zeriontech/zerion-web-app@f5b4675), which itself was a port of this extension component.

- Each search result expands into one row per tradable implementation chain; a selected network chip narrows results to that chain, "All networks" orders chains chip-order-first, then backend order. Held (chain, fungible) pairs are deduped out of the search section.
- Selecting a not-held token flows through the existing zero-balance synthesis in `useFormPositions`, so the form shows Balance: 0 in red with the shake animation and the quote-level "Insufficient balance" warning instead of blocking the pick.
- `InputPositionSelector.onSelect` signature changed from `(position, selectedTab)` to `(chainId, fungibleId, selectedTab)` since not-held rows have no position (the single caller only used those two fields).
- Skeleton rows while the first search page loads; search state now resets on dialog close (also fixes a latent bug where a stale query kept filtering holdings after reopen).
- Promoted `TokenListSkeleton` from `OutputPositionSelector` to the shared `src/ui/components/PositionSelector/`; added an optional `enabled` flag to `useSearchQueryFungibles`.

Closes WLT-1720

## Test plan

- Open Swap → Pay-with selector → type a token symbol you don't hold (e.g. on a fresh wallet): a "Tokens not held in wallet" section appears below holdings with zero-balance rows per tradable chain.
- Select a network chip → search rows narrow to that chain only; "All networks" shows one row per implementation chain, chip-order first.
- Pick a not-held token → selector closes, token is set as Pay-with, balance shows 0; entering an amount shows the insufficient-balance state instead of blocking.
- Tokens you already hold don't duplicate into the search section.
- While search loads, skeleton rows show instead of "No tokens found"; reopening the dialog starts with a clean query.
- Receive selector behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)