### PR TITLE
Preload protocol icons and DNA mint images from their components

### DIFF
--- a/src/ui/DNA/components/MintBanner.tsx
+++ b/src/ui/DNA/components/MintBanner.tsx
@@ -3,8 +3,12 @@ import { VStack } from 'src/ui/ui-kit/VStack';
 import { UIText } from 'src/ui/ui-kit/UIText';
 import { UnstyledAnchor } from 'src/ui/ui-kit/UnstyledAnchor';
 import { openHrefInTabView } from 'src/ui/shared/openUrl';
+import { usePreloadImages } from 'src/ui/shared/usePreloadImages';
 import { DnaBanner } from '../shared/DnaBanner';
+import { MINT_DNA_IMAGES, MINT_DNA_WAITING_IMAGES } from '../shared/constants';
 import * as styles from './styles.module.css';
+
+const NEXT_STEPS_IMAGES = [...MINT_DNA_IMAGES, ...MINT_DNA_WAITING_IMAGES];
 
 export function MintBanner({
   address,
@@ -13,6 +17,10 @@ export function MintBanner({
   address: string;
   onDismiss?(): void;
 }) {
+  // The banner is a "Continue" step into the mint flow, so preload the
+  // images that flow is about to need instead of preloading them for every
+  // popup load regardless of whether the user ever opens the banner.
+  usePreloadImages(NEXT_STEPS_IMAGES);
   return (
     <DnaBanner
       style={{

--- a/src/ui/DNA/pages/MintDnaFlow/MintDna.tsx
+++ b/src/ui/DNA/pages/MintDnaFlow/MintDna.tsx
@@ -35,9 +35,14 @@ import { SidePanel } from 'src/ui/features/onboarding/shared/SidePanel';
 import { useHttpClientSource } from 'src/modules/zerion-api/hooks/useHttpClientSource';
 import { useHttpAddressPositions } from 'src/modules/zerion-api/hooks/useWalletPositions';
 import { usePositionsRefetchInterval } from 'src/ui/transactions/usePositionsRefetchInterval';
+import { usePreloadImages } from 'src/ui/shared/usePreloadImages';
 import * as helpersStyles from '../../shared/styles.module.css';
 import { Step } from '../../shared/Step';
-import { DNA_MINT_CONTRACT_ADDRESS } from '../../shared/constants';
+import {
+  DNA_MINT_CONTRACT_ADDRESS,
+  MINT_DNA_IMAGES,
+  MINT_DNA_WAITING_IMAGES,
+} from '../../shared/constants';
 import * as styles from './styles.module.css';
 
 const ZERION_ORIGIN = 'https://app.zerion.io';
@@ -141,6 +146,11 @@ function MintDnaContent({
 }
 
 export function MintDna() {
+  // Preload the next screen's images in case the user landed here directly
+  // (e.g. a bookmarked link) instead of coming from MintBanner, which
+  // already preloads them ahead of time.
+  usePreloadImages(MINT_DNA_WAITING_IMAGES);
+
   const [animation, setAnimation] = useState(true);
   const firstAppearRef = useSpringRef();
   const firstAppearStyle = useSpring({
@@ -302,7 +312,7 @@ export function MintDna() {
         <div style={{ position: 'absolute', bottom: -4, left: 128 }}>
           <animated.div style={chainAppearStyle[4]}>
             <img
-              src="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/dna-6.png"
+              src={MINT_DNA_IMAGES[0]}
               alt="dna image"
               style={{ objectFit: 'contain', width: 202 }}
             />
@@ -311,7 +321,7 @@ export function MintDna() {
         <div style={{ position: 'absolute', bottom: -4, left: 193 }}>
           <animated.div style={chainAppearStyle[3]}>
             <img
-              src="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/dna-5.png"
+              src={MINT_DNA_IMAGES[1]}
               alt="dna image"
               style={{ objectFit: 'contain', width: 220 }}
             />
@@ -320,7 +330,7 @@ export function MintDna() {
         <div style={{ position: 'absolute', bottom: -4, left: 250 }}>
           <animated.div style={chainAppearStyle[2]}>
             <img
-              src="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/dna-4.png"
+              src={MINT_DNA_IMAGES[2]}
               alt="dna image"
               style={{ width: 248, height: 264 }}
             />
@@ -329,7 +339,7 @@ export function MintDna() {
         <div style={{ position: 'absolute', bottom: -4, left: 330 }}>
           <animated.div style={chainAppearStyle[1]}>
             <img
-              src="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/dna-3.png"
+              src={MINT_DNA_IMAGES[3]}
               alt="dna image"
               style={{ objectFit: 'contain', width: 244 }}
             />
@@ -338,7 +348,7 @@ export function MintDna() {
         <div style={{ position: 'absolute', bottom: -4, left: 385 }}>
           <animated.div style={chainAppearStyle[0]}>
             <img
-              src="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/dna-2.png"
+              src={MINT_DNA_IMAGES[4]}
               alt="dna image"
               style={{ objectFit: 'contain', width: 273 }}
             />
@@ -353,7 +363,7 @@ export function MintDna() {
               }}
             >
               <img
-                src="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/dna-1.png"
+                src={MINT_DNA_IMAGES[5]}
                 alt="dna image"
                 style={{ objectFit: 'contain', width: 270 }}
               />

--- a/src/ui/DNA/pages/MintDnaFlow/MintDnaWaiting.tsx
+++ b/src/ui/DNA/pages/MintDnaFlow/MintDnaWaiting.tsx
@@ -11,7 +11,10 @@ import { CircleSpinner } from 'src/ui/ui-kit/CircleSpinner';
 import { getAddressNfts } from 'src/ui/shared/requests/addressNfts/useAddressNfts';
 import { invariant } from 'src/shared/invariant';
 import * as helpersStyles from '../../shared/styles.module.css';
-import { DNA_COLLECTION_ID } from '../../shared/constants';
+import {
+  DNA_COLLECTION_ID,
+  MINT_DNA_WAITING_IMAGES,
+} from '../../shared/constants';
 import { Step } from '../../shared/Step';
 import * as styles from './styles.module.css';
 
@@ -56,24 +59,24 @@ export function MintDnaWaiting() {
   return (
     <div className={helpersStyles.container} style={{ height: 600 }}>
       <img
-        src="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/minting-1.png"
+        src={MINT_DNA_WAITING_IMAGES[0]}
         alt="minting"
         className={styles.mintingImage}
       />
       <img
-        src="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/minting-2.png"
+        src={MINT_DNA_WAITING_IMAGES[1]}
         alt="minting"
         className={styles.mintingImage}
         style={{ animationDelay: '2000ms' }}
       />
       <img
-        src="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/minting-3.png"
+        src={MINT_DNA_WAITING_IMAGES[2]}
         alt="minting"
         className={styles.mintingImage}
         style={{ animationDelay: '4000ms' }}
       />
       <img
-        src="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/minting-4.png"
+        src={MINT_DNA_WAITING_IMAGES[3]}
         alt="minting"
         className={styles.mintingImage}
         style={{ animationDelay: '6000ms' }}

--- a/src/ui/DNA/shared/DnaBanner.tsx
+++ b/src/ui/DNA/shared/DnaBanner.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import cn from 'classnames';
 import CloseIcon from 'jsx:src/ui/assets/close.svg';
 import { UnstyledButton } from 'src/ui/ui-kit/UnstyledButton';
+import { DNA_BANNER_IMAGE } from './constants';
 import * as styles from './styles.module.css';
 
 export function DnaBanner({
@@ -14,11 +15,7 @@ export function DnaBanner({
 } & React.HTMLProps<HTMLDivElement>) {
   return (
     <div {...props} className={cn(className, styles.banner)}>
-      <img
-        src="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/dna-banner.png"
-        alt="zerion dna"
-        className={styles.image}
-      />
+      <img src={DNA_BANNER_IMAGE} alt="zerion dna" className={styles.image} />
       {onDismiss ? (
         <UnstyledButton
           onClick={onDismiss}

--- a/src/ui/DNA/shared/constants.ts
+++ b/src/ui/DNA/shared/constants.ts
@@ -3,3 +3,27 @@ export const DNA_NFT_COLLECTION_ADDRESS =
   '0x932261f9fc8da46c4a22e31b45c4de60623848bf';
 export const DNA_MINT_CONTRACT_ADDRESS =
   '0x932261f9fc8da46c4a22e31b45c4de60623848bf';
+
+const DNA_ASSETS_BASE_URL =
+  'https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets';
+
+/** Image rendered by {@link DnaBanner}, shown before the mint/upgrade flows. */
+export const DNA_BANNER_IMAGE = `${DNA_ASSETS_BASE_URL}/dna-banner.png`;
+
+/** Images rendered by {@link MintDna} while animating the DNA layers in. */
+export const MINT_DNA_IMAGES = [
+  `${DNA_ASSETS_BASE_URL}/dna-6.png`,
+  `${DNA_ASSETS_BASE_URL}/dna-5.png`,
+  `${DNA_ASSETS_BASE_URL}/dna-4.png`,
+  `${DNA_ASSETS_BASE_URL}/dna-3.png`,
+  `${DNA_ASSETS_BASE_URL}/dna-2.png`,
+  `${DNA_ASSETS_BASE_URL}/dna-1.png`,
+];
+
+/** Images rendered by {@link MintDnaWaiting}, shown right after {@link MintDna}. */
+export const MINT_DNA_WAITING_IMAGES = [
+  `${DNA_ASSETS_BASE_URL}/minting-1.png`,
+  `${DNA_ASSETS_BASE_URL}/minting-2.png`,
+  `${DNA_ASSETS_BASE_URL}/minting-3.png`,
+  `${DNA_ASSETS_BASE_URL}/minting-4.png`,
+];

--- a/src/ui/pages/BridgeForm/BridgeForm.tsx
+++ b/src/ui/pages/BridgeForm/BridgeForm.tsx
@@ -25,6 +25,8 @@ import { NavigationTitle } from 'src/ui/components/NavigationTitle';
 import { PageColumn } from 'src/ui/components/PageColumn';
 import { PageTop } from 'src/ui/components/PageTop';
 import { usePreferences } from 'src/ui/features/preferences';
+import { usePreloadImages } from 'src/ui/shared/usePreloadImages';
+import { PROTOCOL_ICONS_TO_PRELOAD } from 'src/ui/shared/protocolIconsToPreload';
 import { walletPort } from 'src/ui/shared/channels';
 import WarningIcon from 'jsx:src/ui/assets/warning.svg';
 import { getRootDomNode } from 'src/ui/shared/getRootDomNode';
@@ -1819,6 +1821,7 @@ function BridgeFormComponent() {
 }
 
 export function BridgeForm() {
+  usePreloadImages(PROTOCOL_ICONS_TO_PRELOAD);
   const { preferences } = usePreferences();
   if (preferences?.testnetMode?.on) {
     return <Navigate to="/" />;

--- a/src/ui/pages/SwapForm/SwapForm.tsx
+++ b/src/ui/pages/SwapForm/SwapForm.tsx
@@ -65,6 +65,8 @@ import {
 import { AllowanceForm } from 'src/ui/components/AllowanceForm';
 import BigNumber from 'bignumber.js';
 import { usePreferences } from 'src/ui/features/preferences';
+import { usePreloadImages } from 'src/ui/shared/usePreloadImages';
+import { PROTOCOL_ICONS_TO_PRELOAD } from 'src/ui/shared/protocolIconsToPreload';
 import { useCurrency } from 'src/modules/currency/useCurrency';
 import { useHttpClientSource } from 'src/modules/zerion-api/hooks/useHttpClientSource';
 import {
@@ -1674,6 +1676,7 @@ function SwapFormPrepareChain({ children }: React.PropsWithChildren) {
 }
 
 export function SwapForm() {
+  usePreloadImages(PROTOCOL_ICONS_TO_PRELOAD);
   const { preferences } = usePreferences();
   if (preferences?.testnetMode?.on) {
     return <Navigate to="/" />;

--- a/src/ui/pages/SwapForm2/SwapForm2.tsx
+++ b/src/ui/pages/SwapForm2/SwapForm2.tsx
@@ -58,6 +58,8 @@ import { HStack } from 'src/ui/ui-kit/HStack/HStack';
 import { VStack } from 'src/ui/ui-kit/VStack';
 import { useDialog2 } from 'src/ui/ui-kit/ModalDialogs/Dialog2';
 import { useBackgroundKind } from 'src/ui/components/Background';
+import { usePreloadImages } from 'src/ui/shared/usePreloadImages';
+import { PROTOCOL_ICONS_TO_PRELOAD } from 'src/ui/shared/protocolIconsToPreload';
 import { PageBottom } from 'src/ui/components/PageBottom';
 import { Spacer } from 'src/ui/ui-kit/Spacer';
 import { useGasPrices } from 'src/ui/shared/requests/useGasPrices';
@@ -927,6 +929,7 @@ function SwapFormWrapper({
 }
 
 export function SwapForm2() {
+  usePreloadImages(PROTOCOL_ICONS_TO_PRELOAD);
   useBackgroundKind({ kind: 'white' });
   const { preferences } = usePreferences();
   const { singleAddress: address, ready } = useAddressParams();

--- a/src/ui/popup.html
+++ b/src/ui/popup.html
@@ -41,59 +41,152 @@
       crossorigin
     />
 
-    <!-- Preload protocol images for better animations in Forms -->
-    <link rel="preload" as="image" href="https://protocol-icons.s3.amazonaws.com/1inch.png">
-    <link rel="preload" as="image" href="https://protocol-icons.s3.amazonaws.com/uniswap-exchange.png">
-    <link rel="preload" as="image" href="https://protocol-icons.s3.amazonaws.com/uniswap-exchangev3.png">
-    <link rel="preload" as="image" href="https://protocol-icons.s3.amazonaws.com/paraswap.png">
-
-    <!-- DNA Mint Flow -->
-    <link rel="preload" as="image" href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/dna-banner.png"/>
-    <link rel="preload" as="image" href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/dna-6.png" />
-    <link rel="preload" as="image" href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/dna-5.png" />
-    <link rel="preload" as="image" href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/dna-4.png" />
-    <link rel="preload" as="image" href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/dna-3.png" />
-    <link rel="preload" as="image" href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/dna-2.png" />
-    <link rel="preload" as="image" href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/dna-1.png" />
-    <link rel="preload" as="image" href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/minting-4.png" />
-    <link rel="preload" as="image" href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/minting-3.png" />
-    <link rel="preload" as="image" href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/minting-2.png" />
-    <link rel="preload" as="image" href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/minting-1.png" />
+    <!-- Protocol icons and DNA Mint Flow images are now preloaded on-demand
+    from the components that use them (see usePreloadImages), instead of on
+    every popup load regardless of route. See github.com/zeriontech/zerion-wallet-extension/issues/717 -->
 
     <!-- DNA Update Flow -->
-    <link rel="preload" as="image" href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/be-invested.png" />
-    <link rel="preload" as="image" href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/dont-be-maxi.png" />
-    <link rel="preload" as="image" href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/its-all-on-chain.png" />
-    <link rel="preload" as="image" href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/seek-alpha.png" />
-    <link rel="preload" as="image" href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/self-custodial.png" />
+    <link
+      rel="preload"
+      as="image"
+      href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/be-invested.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/dont-be-maxi.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/its-all-on-chain.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/seek-alpha.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/self-custodial.png"
+    />
 
     <!-- Referral Program Flow -->
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/invite-banner-decoration.png" />
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/invite-banner-decoration_2x.png" />
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/invite-flow-decoration-left.png" />
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/invite-flow-decoration-left_2x.png" />
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/invite-flow-decoration-right.png" />
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/invite-flow-decoration-right_2x.png" />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/invite-banner-decoration.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/invite-banner-decoration_2x.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/invite-flow-decoration-left.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/invite-flow-decoration-left_2x.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/invite-flow-decoration-right.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/invite-flow-decoration-right_2x.png"
+    />
 
     <!-- XP Drop Flow -->
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/extension-xp-drop-rewards.png" />
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/extension-xp-drop-rewards_2x.png" />
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/extension-xp-drop-quests.png" />
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/extension-xp-drop-quests_2x.png" />
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/extension-xp-drop-dna.png" />
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/extension-xp-drop-dna_2x.png" />
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/extension-xp-drop-levels.png" />
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/extension-xp-drop-levels_2x.png" />
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/rotating-zero.png" />
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/rotating-zero_2x.png" />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/extension-xp-drop-rewards.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/extension-xp-drop-rewards_2x.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/extension-xp-drop-quests.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/extension-xp-drop-quests_2x.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/extension-xp-drop-dna.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/extension-xp-drop-dna_2x.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/extension-xp-drop-levels.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/extension-xp-drop-levels_2x.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/rotating-zero.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/rotating-zero_2x.png"
+    />
 
     <!-- Perps Onboarding Flow -->
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/perps_onboarding_1.png" />
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/perps_onboarding_1_2x.png" />
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/perps_onboarding_2.png" />
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/perps_onboarding_2_2x.png" />
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/perps_onboarding_3.png" />
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/perps_onboarding_3_2.png" />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/perps_onboarding_1.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/perps_onboarding_1_2x.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/perps_onboarding_2.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/perps_onboarding_2_2x.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/perps_onboarding_3.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/perps_onboarding_3_2.png"
+    />
 
     <title>Zerion</title>
   </head>

--- a/src/ui/popup.html
+++ b/src/ui/popup.html
@@ -43,7 +43,7 @@
 
     <!-- Protocol icons and DNA Mint Flow images are now preloaded on-demand
     from the components that use them (see usePreloadImages), instead of on
-    every popup load regardless of route. See github.com/zeriontech/zerion-wallet-extension/issues/717 -->
+    every popup load regardless of route. See https://github.com/zeriontech/zerion-wallet-extension/issues/717 -->
 
     <!-- DNA Update Flow -->
     <link

--- a/src/ui/shared/protocolIconsToPreload.ts
+++ b/src/ui/shared/protocolIconsToPreload.ts
@@ -1,0 +1,12 @@
+/**
+ * Icons of the swap/bridge providers most commonly returned in quotes.
+ * Preloaded from the swap/bridge forms (see {@link usePreloadImages}) so
+ * they're already cached by the time the quote list renders them via
+ * `quote.contractMetadata.iconUrl`, for smoother animations in Forms.
+ */
+export const PROTOCOL_ICONS_TO_PRELOAD = [
+  'https://protocol-icons.s3.amazonaws.com/1inch.png',
+  'https://protocol-icons.s3.amazonaws.com/uniswap-exchange.png',
+  'https://protocol-icons.s3.amazonaws.com/uniswap-exchangev3.png',
+  'https://protocol-icons.s3.amazonaws.com/paraswap.png',
+];

--- a/src/ui/shared/usePreloadImages.ts
+++ b/src/ui/shared/usePreloadImages.ts
@@ -29,5 +29,5 @@ export function usePreloadImages(urls: string[]) {
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [urls.join(',')]);
+  }, [JSON.stringify(urls)]);
 }

--- a/src/ui/shared/usePreloadImages.ts
+++ b/src/ui/shared/usePreloadImages.ts
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+
+/**
+ * Injects `<link rel="preload" as="image">` tags for the given URLs into
+ * `document.head` while the calling component is mounted, and removes them
+ * on unmount.
+ *
+ * Use this instead of hardcoding `<link rel="preload">` tags in the HTML
+ * entry files: a preload declared in HTML is fetched on every page load
+ * regardless of whether the user ever reaches the screen that needs it,
+ * which is exactly what triggers Chrome's "was preloaded but not used"
+ * console warning. Calling this hook from the component that is about to
+ * render the image (or from the screen shown right before it) preloads the
+ * resource only when it is actually going to be used.
+ */
+export function usePreloadImages(urls: string[]) {
+  useEffect(() => {
+    const links = urls.map((url) => {
+      const link = document.createElement('link');
+      link.rel = 'preload';
+      link.as = 'image';
+      link.href = url;
+      document.head.appendChild(link);
+      return link;
+    });
+    return () => {
+      for (const link of links) {
+        link.remove();
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [urls.join(',')]);
+}

--- a/src/ui/sidepanel.html
+++ b/src/ui/sidepanel.html
@@ -37,7 +37,7 @@
 
     <!-- Protocol icons and DNA Mint Flow images are now preloaded on-demand
     from the components that use them (see usePreloadImages), instead of on
-    every popup load regardless of route. See github.com/zeriontech/zerion-wallet-extension/issues/717 -->
+    every sidepanel load regardless of route. See https://github.com/zeriontech/zerion-wallet-extension/issues/717 -->
 
     <!-- DNA Update Flow -->
     <link

--- a/src/ui/sidepanel.html
+++ b/src/ui/sidepanel.html
@@ -35,57 +35,142 @@
       crossorigin
     />
 
-    <!-- Preload protocol images for better animations in Forms -->
-    <link rel="preload" as="image" href="https://protocol-icons.s3.amazonaws.com/1inch.png">
-    <link rel="preload" as="image" href="https://protocol-icons.s3.amazonaws.com/uniswap-exchange.png">
-    <link rel="preload" as="image" href="https://protocol-icons.s3.amazonaws.com/uniswap-exchangev3.png">
-    <link rel="preload" as="image" href="https://protocol-icons.s3.amazonaws.com/paraswap.png">
-
-    <!-- DNA Mint Flow -->
-    <link rel="preload" as="image" href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/dna-banner.png"/>
-    <link rel="preload" as="image" href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/dna-6.png" />
-    <link rel="preload" as="image" href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/dna-5.png" />
-    <link rel="preload" as="image" href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/dna-4.png" />
-    <link rel="preload" as="image" href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/dna-3.png" />
-    <link rel="preload" as="image" href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/dna-2.png" />
-    <link rel="preload" as="image" href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/dna-1.png" />
-    <link rel="preload" as="image" href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/minting-4.png" />
-    <link rel="preload" as="image" href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/minting-3.png" />
-    <link rel="preload" as="image" href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/minting-2.png" />
-    <link rel="preload" as="image" href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/minting-1.png" />
+    <!-- Protocol icons and DNA Mint Flow images are now preloaded on-demand
+    from the components that use them (see usePreloadImages), instead of on
+    every popup load regardless of route. See github.com/zeriontech/zerion-wallet-extension/issues/717 -->
 
     <!-- DNA Update Flow -->
-    <link rel="preload" as="image" href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/be-invested.png" />
-    <link rel="preload" as="image" href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/dont-be-maxi.png" />
-    <link rel="preload" as="image" href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/its-all-on-chain.png" />
-    <link rel="preload" as="image" href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/seek-alpha.png" />
-    <link rel="preload" as="image" href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/self-custodial.png" />
+    <link
+      rel="preload"
+      as="image"
+      href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/be-invested.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/dont-be-maxi.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/its-all-on-chain.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/seek-alpha.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://s3.amazonaws.com/cdn.zerion.io/images/dna-assets/self-custodial.png"
+    />
 
     <!-- Referral Program Flow -->
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/invite-banner-decoration.png" />
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/invite-banner-decoration_2x.png" />
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/invite-flow-decoration-left.png" />
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/invite-flow-decoration-left_2x.png" />
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/invite-flow-decoration-right.png" />
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/invite-flow-decoration-right_2x.png" />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/invite-banner-decoration.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/invite-banner-decoration_2x.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/invite-flow-decoration-left.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/invite-flow-decoration-left_2x.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/invite-flow-decoration-right.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/invite-flow-decoration-right_2x.png"
+    />
 
     <!-- XP Drop Flow -->
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/extension-xp-drop-rewards.png" />
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/extension-xp-drop-rewards_2x.png" />
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/extension-xp-drop-quests.png" />
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/extension-xp-drop-quests_2x.png" />
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/extension-xp-drop-dna.png" />
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/extension-xp-drop-dna_2x.png" />
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/extension-xp-drop-levels.png" />
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/extension-xp-drop-levels_2x.png" />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/extension-xp-drop-rewards.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/extension-xp-drop-rewards_2x.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/extension-xp-drop-quests.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/extension-xp-drop-quests_2x.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/extension-xp-drop-dna.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/extension-xp-drop-dna_2x.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/extension-xp-drop-levels.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/extension-xp-drop-levels_2x.png"
+    />
 
     <!-- Perps Onboarding Flow -->
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/perps_onboarding_1.png" />
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/perps_onboarding_1_2x.png" />
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/perps_onboarding_2.png" />
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/perps_onboarding_2_2x.png" />
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/perps_onboarding_3.png" />
-    <link rel="preload" as="image" href="https://cdn.zerion.io/images/dna-assets/perps_onboarding_3_2.png" />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/perps_onboarding_1.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/perps_onboarding_1_2x.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/perps_onboarding_2.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/perps_onboarding_2_2x.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/perps_onboarding_3.png"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://cdn.zerion.io/images/dna-assets/perps_onboarding_3_2.png"
+    />
 
     <title>Zerion</title>
     <script type="module" src="./index.tsx"></script>


### PR DESCRIPTION
## What

Fixes #717 — Chrome logs *"The resource was preloaded using link preload but not used within a few seconds from the window's load event"* for the protocol-icon and DNA-mint-flow images, because `popup.html`/`sidepanel.html` preload them unconditionally on every popup open, regardless of which screen (if any) the user visits.

Per the issue's suggestion, this moves preloading into the components that actually need the images, using a small reusable hook:

- **`usePreloadImages(urls)`** (`src/ui/shared/usePreloadImages.ts`) injects `<link rel="preload" as="image">` tags into `document.head` on mount and removes them on unmount.
- **Protocol icons** (1inch, Uniswap, Uniswap v3, ParaSwap): preloaded from `SwapForm`, `BridgeForm`, and `SwapForm2` (covers both the old and new swap/bridge routes) right when the form mounts, ahead of the quote list rendering `quote.contractMetadata.iconUrl`.
- **DNA mint flow images**: `MintBanner` (the "Continue" banner shown before the mint flow, on the NFT tab / Settings page) preloads the images used by `MintDna` and the following `MintDnaWaiting` screen. `MintDna` also preloads the waiting-screen images itself, in case a user lands there directly (e.g. a bookmarked link) instead of via the banner.
- Removed the corresponding static `<link rel="preload">` tags from `popup.html` and `sidepanel.html`.
- Deduplicated the image URLs into `src/ui/DNA/shared/constants.ts` and `src/ui/shared/protocolIconsToPreload.ts` so they're defined once instead of separately in the HTML and in each consuming component.

## Out of scope

`popup.html`/`sidepanel.html` still statically preload a few other image groups (DNA update/quiz flow, referral program, XP drop, Perps onboarding) that have the same warning but weren't named in #717. Same `usePreloadImages` hook can be applied to those from their respective entry components as a follow-up.

## Testing

- `npx tsc --noEmit` — passes.
- `npx eslint` on all changed files — passes.