### PR TITLE
WLT-1998: show the full recipient address in address picker rows

### DIFF
--- a/src/ui/components/FullAddress/FullAddress.module.css
+++ b/src/ui/components/FullAddress/FullAddress.module.css
@@ -1,0 +1,17 @@
+.row {
+  display: grid;
+  grid-template-columns: auto minmax(min-content, 1fr);
+  align-items: center;
+  min-width: 0;
+  justify-content: start;
+}
+
+.head {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tail {
+  white-space: nowrap;
+}

--- a/src/ui/components/FullAddress/FullAddress.tsx
+++ b/src/ui/components/FullAddress/FullAddress.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import cn from 'classnames';
+import { UIText } from 'src/ui/ui-kit/UIText';
+import type { Kind as UITextKind } from 'src/ui/ui-kit/UIText';
+import * as styles from './FullAddress.module.css';
+
+const TAIL_LENGTH = 6;
+
+/**
+ * Renders the whole address so that it can be verified against the source it
+ * was copied from. When there isn't enough room for it, the head is ellipsized
+ * and the last {@link TAIL_LENGTH} characters stay pinned — the tail is the
+ * part people compare, so it must never be the part that gets cut.
+ */
+export function FullAddress({
+  address,
+  kind = 'caption/regular',
+  color = 'var(--neutral-500)',
+  className,
+}: {
+  address: string;
+  kind?: UITextKind;
+  color?: string;
+  className?: string;
+}) {
+  const head = address.slice(0, -TAIL_LENGTH);
+  const tail = address.slice(-TAIL_LENGTH);
+
+  return (
+    <div className={cn(styles.row, className)} title={address}>
+      <UIText kind={kind} color={color} className={styles.head}>
+        {head}
+      </UIText>
+      <UIText kind={kind} color={color} className={styles.tail}>
+        {tail}
+      </UIText>
+    </div>
+  );
+}

--- a/src/ui/components/FullAddress/index.ts
+++ b/src/ui/components/FullAddress/index.ts
@@ -1,0 +1,1 @@
+export { FullAddress } from './FullAddress';

--- a/src/ui/components/ReceiverAddressDialog/AddressListItem.tsx
+++ b/src/ui/components/ReceiverAddressDialog/AddressListItem.tsx
@@ -4,6 +4,7 @@ import { normalizeAddress } from 'src/shared/normalizeAddress';
 import { truncateAddress } from 'src/ui/shared/truncateAddress';
 import { useWalletsMetaByChunks } from 'src/ui/shared/requests/useWalletsMetaByChunks';
 import { BlockieImg } from 'src/ui/components/BlockieImg';
+import { FullAddress } from 'src/ui/components/FullAddress';
 import { UIText } from 'src/ui/ui-kit/UIText';
 import { VStack } from 'src/ui/ui-kit/VStack';
 
@@ -64,9 +65,9 @@ export function AddressListItem({
   const previewUrl = meta?.nft?.previewUrl ?? null;
   const firstHandle = meta?.identities?.[0]?.handle ?? null;
 
-  const truncated = truncateAddress(normalizeAddress(address), 5);
-  const title = localName || firstHandle || truncated;
-  const subtitle = truncated;
+  const normalizedAddress = normalizeAddress(address);
+  const title =
+    localName || firstHandle || truncateAddress(normalizedAddress, 5);
 
   return (
     <>
@@ -105,17 +106,7 @@ export function AddressListItem({
         >
           {title}
         </UIText>
-        <UIText
-          kind="caption/regular"
-          color="var(--neutral-500)"
-          style={{
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-          }}
-        >
-          {subtitle}
-        </UIText>
+        <FullAddress address={normalizedAddress} />
       </VStack>
     </>
   );

--- a/src/ui/pages/SendForm2/ReceiverAddressSelector/ReceiverAddressSelector.module.css
+++ b/src/ui/pages/SendForm2/ReceiverAddressSelector/ReceiverAddressSelector.module.css
@@ -61,24 +61,6 @@
   pointer-events: auto;
 }
 
-.addressRow {
-  display: grid;
-  grid-template-columns: auto minmax(min-content, 1fr);
-  align-items: center;
-  min-width: 0;
-  justify-content: start;
-}
-
-.addressHead {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.addressTail {
-  white-space: nowrap;
-}
-
 .skeletonAvatar {
   width: 24px;
   height: 24px;

--- a/src/ui/pages/SendForm2/ReceiverAddressSelector/ReceiverAddressSelector.tsx
+++ b/src/ui/pages/SendForm2/ReceiverAddressSelector/ReceiverAddressSelector.tsx
@@ -6,6 +6,7 @@ import { isMatchForEcosystem } from 'src/shared/wallet/shared';
 import type { BlockchainType } from 'src/shared/wallet/classifiers';
 import { truncateAddress } from 'src/ui/shared/truncateAddress';
 import { BlockieImg } from 'src/ui/components/BlockieImg';
+import { FullAddress } from 'src/ui/components/FullAddress';
 import { UIText } from 'src/ui/ui-kit/UIText';
 import { UnstyledButton } from 'src/ui/ui-kit/UnstyledButton';
 import { Button } from 'src/ui/ui-kit/Button';
@@ -88,9 +89,6 @@ export function ReceiverAddressSelector({
       truncateAddress(normalizedTo, 4)
     );
   }, [normalizedTo, display]);
-
-  const addressHead = normalizedTo ? normalizedTo.slice(0, -6) : '';
-  const addressTail = normalizedTo ? normalizedTo.slice(-6) : '';
 
   const handleOpenAddToBook = useCallback(
     (event: React.MouseEvent) => {
@@ -185,22 +183,7 @@ export function ReceiverAddressSelector({
                 {renderRightAction()}
               </div>
               <div style={{ height: 4 }} />
-              <div className={styles.addressRow} title={normalizedTo}>
-                <UIText
-                  kind="caption/regular"
-                  color="var(--neutral-500)"
-                  className={styles.addressHead}
-                >
-                  {addressHead}
-                </UIText>
-                <UIText
-                  kind="caption/regular"
-                  color="var(--neutral-500)"
-                  className={styles.addressTail}
-                >
-                  {addressTail}
-                </UIText>
-              </div>
+              <FullAddress address={normalizedTo} />
             </>
           ) : (
             <>

--- a/src/ui/pages/SwapForm2/ReceiverAddressSelector/ReceiverAddressSelector.module.css
+++ b/src/ui/pages/SwapForm2/ReceiverAddressSelector/ReceiverAddressSelector.module.css
@@ -80,20 +80,3 @@
   flex: 1;
   padding-right: 36px;
 }
-
-.addressRow {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: center;
-  min-width: 0;
-}
-
-.addressHead {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.addressTail {
-  white-space: nowrap;
-}

--- a/src/ui/pages/SwapForm2/ReceiverAddressSelector/ReceiverAddressSelector.tsx
+++ b/src/ui/pages/SwapForm2/ReceiverAddressSelector/ReceiverAddressSelector.tsx
@@ -7,6 +7,7 @@ import { normalizeAddress } from 'src/shared/normalizeAddress';
 import { isMatchForEcosystem } from 'src/shared/wallet/shared';
 import { truncateAddress } from 'src/ui/shared/truncateAddress';
 import { BlockieImg } from 'src/ui/components/BlockieImg';
+import { FullAddress } from 'src/ui/components/FullAddress';
 import { UIText } from 'src/ui/ui-kit/UIText';
 import { VStack } from 'src/ui/ui-kit/VStack';
 import { UnstyledButton } from 'src/ui/ui-kit/UnstyledButton';
@@ -110,8 +111,6 @@ export function ReceiverAddressSelector({
   }
 
   const hasValue = Boolean(formState.to);
-  const addressHead = normalizedTo ? normalizedTo.slice(0, -6) : '';
-  const addressTail = normalizedTo ? normalizedTo.slice(-6) : '';
 
   return (
     <>
@@ -171,22 +170,7 @@ export function ReceiverAddressSelector({
                 >
                   {resolvedTitle}
                 </UIText>
-                <div className={styles.addressRow}>
-                  <UIText
-                    kind="caption/regular"
-                    color="var(--neutral-500)"
-                    className={styles.addressHead}
-                  >
-                    {addressHead}
-                  </UIText>
-                  <UIText
-                    kind="caption/regular"
-                    color="var(--neutral-500)"
-                    className={styles.addressTail}
-                  >
-                    {addressTail}
-                  </UIText>
-                </div>
+                <FullAddress address={normalizedTo} />
               </VStack>
             </div>
             <div className={styles.actions}>


### PR DESCRIPTION
## Summary

In the Send flow's recipient picker, a row showed the truncated address on **both** lines — the title fell back to `0xd8f50…0de1e` and the subtitle repeated it. So at the moment the user clicked to commit a freshly pasted recipient, the full address wasn't visible anywhere on screen (the search input has scrolled past its head by then), and there was nothing to check a clipboard-hijack swap against.

The second line of each row now carries the **full** address.

- New shared `FullAddress` component. It ellipsizes the head and pins the last 6 characters, so when space runs out it's never the tail — the part people actually compare — that gets cut. A 42-char EVM address fits outright at `caption/regular` in the 425px popup; longer Solana addresses degrade gracefully.
- This markup was already hand-rolled in three places (SendForm2 selector, SwapForm2 selector, PerpsWithdraw) and the fix would have made it four, so the SendForm2 and SwapForm2 recipient selectors are migrated onto the shared component. `PerpsWithdraw` is left alone — unrelated surface.
- Line 1 keeps its existing fallback (name → handle → truncated). On a nameless pasted address that means the truncated form sits above the full one, which is strictly more information than the duplicate it replaces.

Because `ReceiverAddressDialog` is shared, the fix also lands in Swap, Address Book, the Overview send button, and Asset Info — the verification concern is identical on all of them. Decisions and rejected alternatives are written up in the [PRD comment on the issue](https://linear.app/zerion/issue/WLT-1998/extension-send-flow-cant-verify-full-recipient-address-before).

Closes WLT-1998

## Test plan

- [ ] Send flow → tap the `To:` field → paste an EVM address. The **Exact match** row's second line shows the full address, all 42 characters, matching what was pasted.
- [ ] Same with a Solana address from a Solana wallet — the head ellipsizes if needed, the last 6 characters stay visible.
- [ ] Rows under Recents / Address Book / My wallets / Watchlist show name or handle on line 1 and the full address on line 2; nothing wraps and the row height is unchanged.
- [ ] Hovering a row shows the full address as a native tooltip.
- [ ] Send form's `To:` field and Swap's recipient field still render their address line as before (no visual regression from the shared-component migration).
- [ ] Address Book, Overview send button, and Asset Info recipient pickers show the same full-address rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)