### PR TITLE
ci(zerion-wallet-extension): harden workflow trust boundaries, secure git authentication, and remove tracked secrets

### DIFF
--- a/.github/actions/push_qa_repo/action.yml
+++ b/.github/actions/push_qa_repo/action.yml
@@ -21,13 +21,34 @@ runs:
         COMMIT_MESSAGE: ${{ inputs.commit_message }}
       run: |
         TARGET_REPO="github.com/zeriontech/zerion-wallet-extension-qa.git"
-        BRANCH_NAME="${{ github.head_ref || github.ref_name }}"
+
+        if [[ ! "$BRANCH_NAME" =~ ^[A-Za-z0-9][A-Za-z0-9._/-]*$ ]] ||
+          [[ "$BRANCH_NAME" == *..* ]] ||
+          [[ "$BRANCH_NAME" == *//* ]] ||
+          [[ "$BRANCH_NAME" == *"@{"* ]] ||
+          [[ "$BRANCH_NAME" == */ ]] ||
+          [[ "$BRANCH_NAME" == *"." ]] ||
+          [[ "$BRANCH_NAME" == *.lock ]]; then
+          echo "Invalid branch name supplied to the QA repository action."
+          exit 1
+        fi
 
         git config --global user.email "zerts@zerion.io"
         git config --global user.name "QA Bot"
 
-        # Clone the target repository
-        git clone "https://x-access-token:${REPO_TOKEN}@${TARGET_REPO}" qa-repository
+        ASKPASS_SCRIPT="${RUNNER_TEMP}/qa-git-askpass.sh"
+        trap 'rm -f "$ASKPASS_SCRIPT"' EXIT
+        cat > "$ASKPASS_SCRIPT" <<'EOF'
+        #!/usr/bin/env bash
+        printf '%s\n' "$REPO_TOKEN"
+        EOF
+        chmod 700 "$ASKPASS_SCRIPT"
+        export GIT_ASKPASS="$ASKPASS_SCRIPT"
+        export GIT_TERMINAL_PROMPT=0
+
+        # Clone the target repository without placing the token in the command line.
+        git clone "https://x-access-token@${TARGET_REPO}" qa-repository
+
         cd qa-repository
 
         # Create or switch to the new branch

--- a/.github/scripts/set-env-from-pr-labels.sh
+++ b/.github/scripts/set-env-from-pr-labels.sh
@@ -8,12 +8,17 @@ if [ -z "$PR_NUMBER" ]; then
   exit 0 # exit without failing
 fi
 
-LABELS=$(gh pr view $PR_NUMBER --json labels -q '.labels[].name')
+if [[ ! "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "Invalid PR number."
+  exit 1
+fi
 
-while read -r line; do
-  if [[ "$line" == ENV_* ]]; then
+LABELS=$(gh pr view "$PR_NUMBER" --json labels -q '.labels[].name')
+
+while IFS= read -r line; do
+  if [[ "$line" =~ ^ENV_[A-Z0-9_]+$ ]]; then
     ENV_NAME="${line#ENV_}" # removes ENV_ prefix
-    echo "$ENV_NAME=on" >> $GITHUB_ENV
+    echo "$ENV_NAME=on" >> "$GITHUB_ENV"
     echo "Set env var found in PR label: $ENV_NAME=on"
   fi
 done <<< "$LABELS"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -68,7 +68,7 @@ jobs:
           BACKEND_ENV: ${{ github.event.inputs.BACKEND_ENV || '' }}
           PROXY_URL: ${{ github.event.inputs.PROXY_URL || 'https://proxy.zerion.io/' }}
           DEFI_SDK_TRANSACTIONS_API_URL: ${{ github.event.inputs.DEFI_SDK_TRANSACTIONS_API_URL || 'https://transactions.zerion.io' }}
-          DEFI_SDK_API_TOKEN: Zerion.0JOY6zZTTw6yl5Cvz9sdmXc7d5AhzVMG
+          DEFI_SDK_API_TOKEN: ${{ secrets.DEFI_SDK_API_TOKEN }}
           TEST_WALLET_ADDRESS: ${{ secrets.TEST_WALLET_ADDRESS }}
           MIXPANEL_TOKEN_PUBLIC: ${{ secrets.MIXPANEL_TOKEN_PUBLIC_DEV }}
           GOOGLE_ANALYTICS_MEASUREMENT_ID: ${{ secrets.GOOGLE_ANALYTICS_MEASUREMENT_ID }}
@@ -91,8 +91,12 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.inputs.PR_NUMBER || github.event.number }}
         run: |
+          if [[ ! "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "Invalid PR number."
+            exit 1
+          fi
           mkdir -p ./pr
-          echo $PR_NUMBER > ./pr/pr_number
+          printf '%s\n' "$PR_NUMBER" > ./pr/pr_number
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: pr_number

--- a/.github/workflows/pr_attach_build.yml
+++ b/.github/workflows/pr_attach_build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-      contents: write
+      contents: read
       actions: read
     steps:
       - name: 'Download PR number'
@@ -49,12 +49,16 @@ jobs:
         id: get-build-artifacts
         if: ${{ github.event.workflow_run.conclusion == 'success' }}
         run: |
-          set -x
           run_number=${{ github.event.workflow_run.run_number }}
           check_suite_id=${{ github.event.workflow_run.check_suite_id }}
           repository_url=${{ github.server_url }}/${{ github.repository }}
           pr_number=$(cat ./pr_number)
-          build_artifact_id=$(curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/artifacts" | jq ".artifacts[1].id")
+          build_artifact_id=$(curl --fail --silent --show-error \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/artifacts" \
+            | jq -er '.artifacts[] | select(.name == "zerion-wallet-extension") | .id')
+
           # We can not use "url" or "archive_download_url" here,
           # hence we need to figure out the artifact's URL "manually"
           build_download_url=${repository_url}/suites/${check_suite_id}/artifacts/${build_artifact_id}

--- a/.github/workflows/pr_push_qa.yml
+++ b/.github/workflows/pr_push_qa.yml
@@ -77,7 +77,7 @@ jobs:
           BACKEND_ENV: ${{ github.event.inputs.BACKEND_ENV || '' }}
           PROXY_URL: ${{ github.event.inputs.PROXY_URL || 'https://proxy.zerion.io/' }}
           DEFI_SDK_TRANSACTIONS_API_URL: ${{ github.event.inputs.DEFI_SDK_TRANSACTIONS_API_URL || 'https://transactions.zerion.io' }}
-          DEFI_SDK_API_TOKEN: Zerion.0JOY6zZTTw6yl5Cvz9sdmXc7d5AhzVMG
+          DEFI_SDK_API_TOKEN: ${{ secrets.DEFI_SDK_API_TOKEN }}
           TEST_WALLET_ADDRESS: ${{ secrets.TEST_WALLET_ADDRESS }}
           MIXPANEL_TOKEN_PUBLIC: ${{ secrets.MIXPANEL_TOKEN_PUBLIC_DEV }}
           GOOGLE_ANALYTICS_MEASUREMENT_ID: ${{ secrets.GOOGLE_ANALYTICS_MEASUREMENT_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           ZERION_TESTNET_API_URL: https://zpi-testnet.zerion.io/
           PROXY_URL: https://proxy.zerion.io/
           DEFI_SDK_TRANSACTIONS_API_URL: https://transactions.zerion.io
-          DEFI_SDK_API_TOKEN: Zerion.0JOY6zZTTw6yl5Cvz9sdmXc7d5AhzVMG
+          DEFI_SDK_API_TOKEN: ${{ secrets.DEFI_SDK_API_TOKEN }}
           TEST_WALLET_ADDRESS: ${{ secrets.TEST_WALLET_ADDRESS }}
           MIXPANEL_TOKEN_PUBLIC: ${{ secrets.MIXPANEL_TOKEN_PUBLIC_PROD }}
           GOOGLE_ANALYTICS_MEASUREMENT_ID: ${{ secrets.GOOGLE_ANALYTICS_MEASUREMENT_ID }}

--- a/.github/workflows/release_push_qa.yml
+++ b/.github/workflows/release_push_qa.yml
@@ -27,7 +27,7 @@ jobs:
           ZERION_TESTNET_API_URL: https://zpi-testnet.zerion.io/
           PROXY_URL: https://proxy.zerion.io/
           DEFI_SDK_TRANSACTIONS_API_URL: https://transactions.zerion.io
-          DEFI_SDK_API_TOKEN: Zerion.0JOY6zZTTw6yl5Cvz9sdmXc7d5AhzVMG
+          DEFI_SDK_API_TOKEN: ${{ secrets.DEFI_SDK_API_TOKEN }}
           TEST_WALLET_ADDRESS: ${{ secrets.TEST_WALLET_ADDRESS }}
           MIXPANEL_TOKEN_PUBLIC: ${{ secrets.MIXPANEL_TOKEN_PUBLIC_PROD }}
           GOOGLE_ANALYTICS_MEASUREMENT_ID: ${{ secrets.GOOGLE_ANALYTICS_MEASUREMENT_ID }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ env:
   BACKEND_ENV: ${{ github.event.inputs.BACKEND_ENV || '' }}
   PROXY_URL: ${{ github.event.inputs.PROXY_URL || 'https://proxy.zerion.io/' }}
   DEFI_SDK_TRANSACTIONS_API_URL: ${{ github.event.inputs.DEFI_SDK_TRANSACTIONS_API_URL || 'https://transactions.zerion.io' }}
-  DEFI_SDK_API_TOKEN: Zerion.0JOY6zZTTw6yl5Cvz9sdmXc7d5AhzVMG
+  DEFI_SDK_API_TOKEN: ${{ secrets.DEFI_SDK_API_TOKEN }}
   TEST_WALLET_ADDRESS: ${{ secrets.TEST_WALLET_ADDRESS }}
   FEATURE_SEND_FORM: on
   MIXPANEL_TOKEN_PUBLIC: ${{ secrets.MIXPANEL_TOKEN_PUBLIC_DEV }}
@@ -48,7 +48,7 @@ jobs:
           BACKEND_ENV: ${{ github.event.inputs.BACKEND_ENV || '' }}
           PROXY_URL: ${{ github.event.inputs.PROXY_URL || 'https://proxy.zerion.io/' }}
           DEFI_SDK_TRANSACTIONS_API_URL: ${{ github.event.inputs.DEFI_SDK_TRANSACTIONS_API_URL || 'https://transactions.zerion.io' }}
-          DEFI_SDK_API_TOKEN: Zerion.0JOY6zZTTw6yl5Cvz9sdmXc7d5AhzVMG
+          DEFI_SDK_API_TOKEN: ${{ secrets.DEFI_SDK_API_TOKEN }}
           TEST_WALLET_ADDRESS: ${{ secrets.TEST_WALLET_ADDRESS }}
           MIXPANEL_TOKEN_PUBLIC: ${{ secrets.MIXPANEL_TOKEN_PUBLIC_DEV }}
           GOOGLE_ANALYTICS_MEASUREMENT_ID: ${{ secrets.GOOGLE_ANALYTICS_MEASUREMENT_ID }}


### PR DESCRIPTION
### Description
This PR addresses high and medium-severity CI/CD vulnerabilities within the `zerion-wallet-extension` repository. It secures trust boundaries during cross-repository operations, removes tracked build tokens from workflow files, prevents shell injection vectors, and enforces strict artifact and permission handling[cite: 41].

### Key Changes
* **Cross-Repository Trust Boundary (`.github/actions/push_qa_repo/action.yml`):**
  - Added strict regex validation for branch names before initiating any Git operations[cite: 41, 49].
  - Removed the plaintext authentication token from the `git clone` command URL (`https://x-access-token@${TARGET_REPO}`)[cite: 41, 49]. 
  - Migrated authentication to a secure, temporary `GIT_ASKPASS` script that is explicitly removed on exit, alongside disabling terminal prompting (`GIT_TERMINAL_PROMPT=0`)[cite: 41, 49].
* **Input Validation & State Injection (`.github/scripts/set-env-from-pr-labels.sh`, `.github/workflows/pr.yml`):**
  - The script now strictly validates the `PR_NUMBER` input to ensure it is decimal (`^[0-9]+$`) before passing it to the `gh` CLI, mitigating potential shell injection[cite: 41, 50, 54].
  - Restricted environment variable generation from labels to a safe allowlist (`ENV_[A-Z0-9_]+`)[cite: 41, 50].
* **Artifact Integrity & Permissions (`.github/workflows/pr_attach_build.yml`):**
  - Reduced the `contents` permission from `write` to `read` to enforce the principle of least privilege[cite: 41, 51].
  - Removed insecure shell tracing (`set -x`) around token-bearing command construction[cite: 41].
  - Refactored the build artifact selection to identify the artifact explicitly by name (`"zerion-wallet-extension"`) instead of relying on array positions, and implemented fail-fast HTTP handling for `curl` requests[cite: 41, 51].
* **Secrets Management (`*.yml` workflows):**
  - Replaced all instances of tracked API tokens in workflow environments with secure references to `${{ secrets.DEFI_SDK_API_TOKEN }}` across `pr.yml`, `pr_push_qa.yml`, `release.yml`, `release_push_qa.yml`, and `run-tests.yml`[cite: 41, 52, 53, 54, 55, 56].

### Validation & Testing
* **Static Verification:** Extracted shell blocks, label-processing scripts, and GitHub Actions YAML configurations successfully passed `bash -n`, structural, and formatting checks[cite: 41]. 
* **Reviewer Action Required:** The previously tracked build credentials remain in the Git history; repository owners must explicitly rotate and revoke the old tokens to ensure complete security[cite: 41]. Hosted deployment behavior and remote GitHub workflow settings could not be verified in the offline audit environment[cite: 41].