### PR TITLE
WLT-2385: port address/actions → wallet/get-actions (nonce check becomes a boolean)

### DIFF
--- a/src/background/transactions/TransactionService.ts
+++ b/src/background/transactions/TransactionService.ts
@@ -21,7 +21,7 @@ import { normalizeChainId } from 'src/shared/normalizeChainId';
 import { getNetworkByChainId } from 'src/modules/networks/networks-api';
 import type { ChainId } from 'src/modules/ethereum/transactions/ChainId';
 import { normalizeAddress } from 'src/shared/normalizeAddress';
-import { getLatestNonceKnownByBackend } from 'src/modules/ethereum/transactions/getLatestNonceKnownByBackend';
+import { backendKnowsTransaction } from 'src/modules/ethereum/transactions/backendKnowsTransaction';
 import type { Wallet } from 'src/shared/types/Wallet';
 import { invariant } from 'src/shared/invariant';
 import { getDefiSdkClient } from 'src/modules/defi-sdk/background';
@@ -37,7 +37,6 @@ import type { PollingTx } from './TransactionPoller';
 import { TransactionsPoller } from './TransactionPoller';
 
 const FOUR_MINUTES_IN_MS = 1000 * 60 * 4;
-const ONE_DAY_IN_MS = 1000 * 60 * 60 * 24;
 const ONE_DAY_IN_MINUTES = 1 * 60 * 24;
 
 class TransactionsStore extends PersistentStore<StoredTransactions> {
@@ -216,7 +215,7 @@ export class TransactionService {
 
     type Address = string;
     type Key = `${Address}:${ChainId}`;
-    const map = new Map<Key, { hash: string; timestamp: number }>();
+    const map = new Map<Key, { hash: string; nonce: number }>();
 
     for (const item of transactions) {
       if (!item.hash) {
@@ -224,33 +223,34 @@ export class TransactionService {
       }
       const chainId = normalizeChainId(item.transaction.chainId);
       const key = `${item.transaction.from}:${chainId}` as const;
-      map.set(key, { hash: item.hash, timestamp: item.timestamp });
+      map.set(key, { hash: item.hash, nonce: item.transaction.nonce });
     }
 
     const wallet = this.options?.getWallet();
     const preferences = await wallet?.getPreferences({
       context: INTERNAL_SYMBOL_CONTEXT,
     });
-    const client = getDefiSdkClient({
-      on: Boolean(preferences?.testnetMode?.on),
-    });
+    const testnetMode = Boolean(preferences?.testnetMode?.on);
+    // Still needed by getNetworkByChainId; networks move off the defi-sdk
+    // client in WLT-2395.
+    const client = getDefiSdkClient({ on: testnetMode });
+    const source = testnetMode ? 'testnet' : 'mainnet';
 
-    for (const [key, { hash, timestamp }] of map.entries()) {
+    for (const [key, { hash, nonce }] of map.entries()) {
       const [address, chainIdStr] = key.split(':');
       const chainId = chainIdStr as ChainId;
       const network = await getNetworkByChainId(chainId, client);
       if (network?.supports_actions) {
-        const knownNonce = await getLatestNonceKnownByBackend({
+        // The nonce comes from the local store: the backend is only asked
+        // whether it has seen this hash yet.
+        const known = await backendKnowsTransaction({
           address,
           hash,
           chain: network.id,
-          // subtract one day to create a bigger search window
-          // to account for possible client-time/server-time inconsistencies
-          actions_since: new Date(timestamp - ONE_DAY_IN_MS - 1).toISOString(),
-          client,
+          source,
         });
-        if (knownNonce != null) {
-          this.purgeEntries({ address, chainId, fromNonce: knownNonce });
+        if (known) {
+          this.purgeEntries({ address, chainId, fromNonce: nonce });
         }
       }
     }

--- a/src/modules/ethereum/transactions/backendKnowsTransaction.ts
+++ b/src/modules/ethereum/transactions/backendKnowsTransaction.ts
@@ -1,7 +1,18 @@
-import type { AddressAction, Client } from 'defi-sdk';
+import type { NetworksSource } from 'src/modules/zerion-api/shared';
+import { ZerionAPI } from 'src/modules/zerion-api/zerion-api.background';
 import { rejectAfterDelay } from 'src/shared/rejectAfterDelay';
 
-export async function getLatestNonceKnownByBackend(params: {
+/**
+ * Answers "has the backend seen transaction {hash} yet?".
+ *
+ * This used to be `getLatestNonceKnownByBackend`, which read
+ * `actions[0].transaction.nonce` off the same request. ZPI's `ActionTransaction`
+ * carries no nonce — but the caller never needed the round trip: it searches by
+ * the hash of a transaction it stored itself, so the nonce coming back was
+ * always the nonce it already had locally. The existence of the action is the
+ * only new information, so that is all this returns.
+ */
+export async function backendKnowsTransaction(params: {
   address: string;
   chain: string;
   /**
@@ -23,51 +34,25 @@ export async function getLatestNonceKnownByBackend(params: {
    * These downsides are edge-cases and should be eventually-resolvable when a newer transaction is submitted.
    */
   hash: string;
-  /**
-   * Format: "2024-06-20T16:56:56.345Z" ({Date.toISOString()})
-   * Pass this to backend to optimize search. It will not look further than the provided date
-   */
-  actions_since?: string;
-  client: Client;
-}): Promise<number | null> {
-  const { address, chain, hash, actions_since, client } = params;
-  const payload: Record<string, unknown> = {
-    address,
+  source: NetworksSource;
+}): Promise<boolean> {
+  const { address, chain, hash, source } = params;
+  // The socket request also carried {actions_since} to narrow the server-side
+  // search. ZPI has no equivalent; it was an optimisation, not a correctness
+  // bound, and this runs on a daily background alarm, so it is simply dropped.
+  const payload = {
     currency: 'usd',
-    actions_chains: [chain],
-    actions_search_query: hash,
-    actions_limit: 1,
+    addresses: [address],
+    chain,
+    searchQuery: hash,
+    limit: 1,
   };
-  if (actions_since) {
-    payload.actions_since = actions_since;
-  }
-  return Promise.race([
-    new Promise<AddressAction[]>((resolve) => {
-      const { unsubscribe } = client.cachedSubscribe<
-        AddressAction[],
-        'address',
-        'actions'
-      >({
-        method: 'get',
-        namespace: 'address',
-        body: { scope: ['actions'], payload },
-        onData: ({ value }) => {
-          if (value) {
-            resolve(value);
-            unsubscribe();
-          }
-        },
-      });
-    }),
+  const response = await Promise.race([
+    ZerionAPI.walletGetActions(payload, { source }),
     rejectAfterDelay(
       10000,
-      `getLatestNonceKnownByBackend(${JSON.stringify(payload)})`
+      `backendKnowsTransaction(${JSON.stringify(payload)})`
     ),
-  ]).then((actions) => {
-    if (actions.length) {
-      return actions[0].transaction.nonce;
-    } else {
-      return null;
-    }
-  });
+  ]);
+  return response.data.length > 0;
 }


### PR DESCRIPTION
Part of [WLT-2383](https://linear.app/zerion/issue/WLT-2383/extension-remove-defi-sdk-incrementally-one-request-per-pr) — incremental defi-sdk removal, **PR 2 of 13**, stacked on #968. Ticket: [WLT-2385](https://linear.app/zerion/issue/WLT-2385/pr-2-addressactions-walletget-actions-nonce-check-becomes-a-boolean). Decision: [WLT-2182](https://linear.app/zerion/issue/WLT-2182/nonce-reconciliation-bound-the-actions-search-without-actions-since).

## What

- `getLatestNonceKnownByBackend` becomes `backendKnowsTransaction`, a **boolean existence check** against the already-existing `wallet/get-actions` endpoint (`data.length > 0`, `limit: 1`). ZPI's `ActionTransaction` has no `nonce` — and the caller never needed the round trip: `performPurgeCheck` searches by the hash of a transaction it stored itself, so it now keeps `item.transaction.nonce` in its map instead of discarding it and asking the backend for the same number back. Behaviour-preserving.
- `actions_since` dropped (search optimisation, not a correctness bound; this runs on a daily alarm) → `ONE_DAY_IN_MS` deleted. The 10s `rejectAfterDelay` guard stays.
- `getDefiSdkClient` stays in `performPurgeCheck`: `getNetworkByChainId` still takes the defi-sdk client on main and moves off it in WLT-2395.

## QA

History nonce reconciliation: send a tx, replace/speed it up externally (or send from another device with the same wallet), confirm the local pending tx gets purged once the backend knows a same-or-higher-nonce action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)