### PR TITLE
WLT-2387 (PR 4/13): port address/activity → wallet/check-activity/v1

### DIFF
--- a/src/modules/zerion-api/requests/wallet-check-activity.ts
+++ b/src/modules/zerion-api/requests/wallet-check-activity.ts
@@ -1,0 +1,59 @@
+import { normalizeAddress } from 'src/shared/normalizeAddress';
+import type { ClientOptions } from '../shared';
+import { ZerionHttpClient } from '../shared';
+import type { ZerionApiContext } from '../zerion-api-bare';
+import type { ResponseBody } from './ResponseBody';
+
+export interface Params {
+  addresses: string[];
+}
+
+interface AddressActivityStatus {
+  address: string;
+  activityStatus: boolean;
+}
+
+export type Response = ResponseBody<AddressActivityStatus[]>;
+
+/**
+ * Shape the old `address`/`activity` socket scope returned. Kept verbatim so
+ * that every consumer (including `helpers.ts`'s `activeWallets[normalizeAddress(
+ * address)]?.active` lookup) is untouched by the migration.
+ */
+export type AddressActivity = Record<
+  string,
+  { address: string; active: boolean }
+>;
+
+/**
+ * ZPI answers with an array; the socket answered with a record. Keying by
+ * `normalizeAddress` rather than by whatever casing the backend echoes is
+ * load-bearing: consumers look up by the normalized address, and a mismatch
+ * would silently report every wallet as inactive.
+ */
+function toAddressActivity(response: Response): AddressActivity {
+  const result: AddressActivity = {};
+  for (const { address, activityStatus } of response.data) {
+    result[normalizeAddress(address)] = { address, active: activityStatus };
+  }
+  return result;
+}
+
+/**
+ * No `Zerion-Wallet-Provider` header on purpose: this is called with addresses
+ * that are not imported yet, so the provider would always resolve to
+ * `viewer_not_added`.
+ */
+export async function walletCheckActivity(
+  this: ZerionApiContext,
+  params: Params,
+  options?: ClientOptions
+) {
+  const endpoint = 'wallet/check-activity/v1';
+  const kyOptions = this.getKyOptions();
+  const response = await ZerionHttpClient.post<Response>(
+    { endpoint, body: JSON.stringify(params), ...options },
+    kyOptions
+  );
+  return toAddressActivity(response);
+}

--- a/src/modules/zerion-api/requests/wallet-check-activity.ts
+++ b/src/modules/zerion-api/requests/wallet-check-activity.ts
@@ -10,40 +10,21 @@ export interface Params {
 
 interface AddressActivityStatus {
   address: string;
-  activityStatus: boolean;
+  active: boolean;
 }
 
 export type Response = ResponseBody<AddressActivityStatus[]>;
 
-/**
- * Shape the old `address`/`activity` socket scope returned. Kept verbatim so
- * that every consumer (including `helpers.ts`'s `activeWallets[normalizeAddress(
- * address)]?.active` lookup) is untouched by the migration.
- */
-export type AddressActivity = Record<
-  string,
-  { address: string; active: boolean }
->;
+export type AddressActivity = Record<string, AddressActivityStatus>;
 
-/**
- * ZPI answers with an array; the socket answered with a record. Keying by
- * `normalizeAddress` rather than by whatever casing the backend echoes is
- * load-bearing: consumers look up by the normalized address, and a mismatch
- * would silently report every wallet as inactive.
- */
 function toAddressActivity(response: Response): AddressActivity {
   const result: AddressActivity = {};
-  for (const { address, activityStatus } of response.data) {
-    result[normalizeAddress(address)] = { address, active: activityStatus };
+  for (const { address, active } of response.data) {
+    result[normalizeAddress(address)] = { address, active };
   }
   return result;
 }
 
-/**
- * No `Zerion-Wallet-Provider` header on purpose: this is called with addresses
- * that are not imported yet, so the provider would always resolve to
- * `viewer_not_added`.
- */
 export async function walletCheckActivity(
   this: ZerionApiContext,
   params: Params,

--- a/src/modules/zerion-api/zerion-api-bare.ts
+++ b/src/modules/zerion-api/zerion-api-bare.ts
@@ -40,6 +40,7 @@ import { depositGetPaymentLink } from './requests/deposit-get-payment-link';
 import { depositGetSupportedCountries } from './requests/deposit-get-supported-countries';
 import { geoGetCountry } from './requests/geo-get-country';
 import { transactionCollect } from './requests/transaction-collect';
+import { walletCheckActivity } from './requests/wallet-check-activity';
 
 export interface ZerionApiContext {
   getAddressProviderHeader(address: string): Promise<string>;
@@ -84,6 +85,7 @@ export const ZerionApiBare = {
   depositGetSupportedCountries,
   geoGetCountry,
   transactionCollect,
+  walletCheckActivity,
 };
 
 export type ZerionApiClient = ZerionApiContext & typeof ZerionApiBare;

--- a/src/shared/analytics/shared/getUserProperties.ts
+++ b/src/shared/analytics/shared/getUserProperties.ts
@@ -1,5 +1,4 @@
 import type { Account } from 'src/background/account/Account';
-import { getAddressActivity } from 'src/ui/shared/requests/useAddressActivity';
 import { INTERNAL_SYMBOL_CONTEXT } from 'src/background/Wallet/Wallet';
 import { isReadonlyContainer } from 'src/shared/types/validators';
 import { backgroundQueryClient } from 'src/modules/query-client/query-client.background';
@@ -16,15 +15,18 @@ import type {
   Params,
   WalletPortfolio,
 } from 'src/modules/zerion-api/requests/wallet-get-portfolio';
+import type { AddressActivity } from 'src/modules/zerion-api/requests/wallet-check-activity';
 import {
   getProviderForMixpanel,
   getProviderNameFromGroup,
 } from './getProviderNameFromGroup';
 import { omitNullParams } from './omitNullParams';
 
-function getFundedStatsByEcosystem(
-  activity: Awaited<ReturnType<typeof getAddressActivity>>
-): { totalCount: number; solanaFundedCount: number; evmFundedCount: number } {
+function getFundedStatsByEcosystem(activity: AddressActivity | null): {
+  totalCount: number;
+  solanaFundedCount: number;
+  evmFundedCount: number;
+} {
   if (!activity) {
     return {
       totalCount: 0,
@@ -47,6 +49,19 @@ function getFundedStatsByEcosystem(
   };
 }
 
+/**
+ * Runs outside React, so the mainnet pinning it used to get accidentally from
+ * the defi-sdk singleton is written out literally here.
+ */
+async function queryAddressActivity(addresses: string[]) {
+  const source = 'mainnet';
+  return backgroundQueryClient.fetchQuery({
+    queryKey: ['walletCheckActivity', addresses, source],
+    queryFn: () => ZerionAPI.walletCheckActivity({ addresses }, { source }),
+    staleTime: 20000,
+  });
+}
+
 async function queryWalletPortfolio(params: Params) {
   return backgroundQueryClient.fetchQuery({
     queryKey: ['walletGetPortfolio', params],
@@ -58,7 +73,7 @@ async function queryWalletPortfolio(params: Params) {
 async function getPortfolioStats(addresses: string[]) {
   return Promise.allSettled([
     queryWalletPortfolio({ addresses, currency: 'usd' }),
-    getAddressActivity({ addresses }, { cachePolicy: 'cache-first' }),
+    queryAddressActivity(addresses),
   ]).then(([result1, result2]) => {
     return {
       portfolio: result1.status === 'fulfilled' ? result1.value : null,

--- a/src/ui/features/onboarding/Import/SelectWallets.tsx
+++ b/src/ui/features/onboarding/Import/SelectWallets.tsx
@@ -180,7 +180,7 @@ export function SelectWallets({
   });
 
   const source = useHttpClientSource();
-  const { value: activeWallets, isLoading: activeWalletsAreLoading } =
+  const { data: activeWallets, isLoading: activeWalletsAreLoading } =
     useAddressActivity(
       { addresses: data?.addressesToCheck || [] },
       { source },

--- a/src/ui/features/onboarding/Import/SelectWallets.tsx
+++ b/src/ui/features/onboarding/Import/SelectWallets.tsx
@@ -18,6 +18,7 @@ import {
 } from 'src/ui/pages/GetStarted/ImportWallet/MnemonicImportView/AddressImportFlow/AddressImportFlow';
 import { WalletListPresentation } from 'src/ui/pages/GetStarted/ImportWallet/MnemonicImportView/AddressImportFlow/WalletList';
 import { useAddressActivity } from 'src/ui/shared/requests/useAddressActivity';
+import { useHttpClientSource } from 'src/modules/zerion-api/hooks/useHttpClientSource';
 import { useAllExistingMnemonicAddresses } from 'src/ui/shared/requests/useAllExistingAddresses';
 import { useStaleTime } from 'src/ui/shared/useStaleTime';
 import { Button } from 'src/ui/ui-kit/Button';
@@ -178,10 +179,12 @@ export function SelectWallets({
     suspense: false,
   });
 
+  const source = useHttpClientSource();
   const { value: activeWallets, isLoading: activeWalletsAreLoading } =
     useAddressActivity(
       { addresses: data?.addressesToCheck || [] },
-      { enabled: Boolean(data?.addressesToCheck), keepStaleData: true }
+      { source },
+      { enabled: Boolean(data?.addressesToCheck), keepPreviousData: true }
     );
 
   const { isStale: isStaleValue } = useStaleTime(activeWallets, 5000);

--- a/src/ui/pages/GetStarted/ImportWallet/MnemonicImportView/MnemonicImportView.tsx
+++ b/src/ui/pages/GetStarted/ImportWallet/MnemonicImportView/MnemonicImportView.tsx
@@ -98,13 +98,13 @@ export function MnemonicImportView({
     useErrorBoundary: true,
   });
   const source = useHttpClientSource();
-  const { value } = useAddressActivity(
+  const { data: activityData } = useAddressActivity(
     { addresses: data?.addressesToCheck || [] },
     { source },
     { enabled: Boolean(data?.addressesToCheck), keepPreviousData: true }
   );
-  const { isStale: isStaleValue } = useStaleTime(value, 3000);
-  const shouldWaitForValue = value == null && !isStaleValue;
+  const { isStale: isStaleValue } = useStaleTime(activityData, 3000);
+  const shouldWaitForValue = activityData == null && !isStaleValue;
   useBackgroundKind(whiteBackgroundKind);
   useBodyStyle(bgStyle);
   return (
@@ -119,7 +119,7 @@ export function MnemonicImportView({
       ) : (
         <AddressImportFlow
           wallets={data.derivedWallets}
-          activeWallets={value ?? {}}
+          activeWallets={activityData ?? {}}
         />
       )}
     </>

--- a/src/ui/pages/GetStarted/ImportWallet/MnemonicImportView/MnemonicImportView.tsx
+++ b/src/ui/pages/GetStarted/ImportWallet/MnemonicImportView/MnemonicImportView.tsx
@@ -9,6 +9,7 @@ import { ViewLoading } from 'src/ui/components/ViewLoading';
 import { maybeTriggerMnemonicRestoration } from 'src/ui/components/MnemonicPhraseRestoration';
 import { walletPort } from 'src/ui/shared/channels';
 import { useAddressActivity } from 'src/ui/shared/requests/useAddressActivity';
+import { useHttpClientSource } from 'src/modules/zerion-api/hooks/useHttpClientSource';
 import { useStaleTime } from 'src/ui/shared/useStaleTime';
 import { useBackgroundKind } from 'src/ui/components/Background';
 import {
@@ -96,9 +97,11 @@ export function MnemonicImportView({
     enabled: Boolean(phrase),
     useErrorBoundary: true,
   });
+  const source = useHttpClientSource();
   const { value } = useAddressActivity(
     { addresses: data?.addressesToCheck || [] },
-    { enabled: Boolean(data?.addressesToCheck), keepStaleData: true }
+    { source },
+    { enabled: Boolean(data?.addressesToCheck), keepPreviousData: true }
   );
   const { isStale: isStaleValue } = useStaleTime(value, 3000);
   const shouldWaitForValue = value == null && !isStaleValue;

--- a/src/ui/shared/requests/useAddressActivity.ts
+++ b/src/ui/shared/requests/useAddressActivity.ts
@@ -16,16 +16,11 @@ export function useAddressActivity(
     keepPreviousData = false,
   }: { enabled?: boolean; keepPreviousData?: boolean } = {}
 ) {
-  const query = useQuery({
+  return useQuery({
     queryKey: ['walletCheckActivity', params, source],
     queryFn: () => ZerionAPI.walletCheckActivity(params, { source }),
     enabled: enabled && params.addresses.length > 0,
     keepPreviousData,
     staleTime: 20000,
   });
-  return {
-    ...query,
-    isLoading: query.isInitialLoading,
-    value: query.data ?? null,
-  };
 }

--- a/src/ui/shared/requests/useAddressActivity.ts
+++ b/src/ui/shared/requests/useAddressActivity.ts
@@ -1,45 +1,31 @@
-import type { CachePolicy } from 'defi-sdk';
-import { createDomainHook, client } from 'defi-sdk';
+import { useQuery } from '@tanstack/react-query';
+import type { Params } from 'src/modules/zerion-api/requests/wallet-check-activity';
+import type { BackendSourceParams } from 'src/modules/zerion-api/shared';
+import { ZerionAPI } from 'src/modules/zerion-api/zerion-api.client';
 
-const namespace = 'address';
-const scope = 'activity';
-
-type Params = { addresses: string[] };
-type Response = Record<string, { address: string; active: boolean }>;
-
-export const useAddressActivity = createDomainHook<
-  Params,
-  Response,
-  typeof namespace,
-  typeof scope
->({
-  namespace,
-  scope,
-});
-
-export async function getAddressActivity(
+/**
+ * `source` is required and has no default on purpose: this hook used to read the
+ * testnet/mainnet channel implicitly from `DefiSdkClientProvider`, so a default
+ * here would silently serve mainnet data in testnet mode.
+ */
+export function useAddressActivity(
   params: Params,
-  options?: { cachePolicy?: CachePolicy }
+  { source }: BackendSourceParams,
+  {
+    enabled = true,
+    keepPreviousData = false,
+  }: { enabled?: boolean; keepPreviousData?: boolean } = {}
 ) {
-  return new Promise<Response | null>((resolve, reject) => {
-    const rejectTimerId = setTimeout(
-      () => reject(new Error('Request timed out: getAddressActivity')),
-      10000
-    );
-    client.cachedSubscribe<Response, typeof namespace, typeof scope>({
-      method: 'get',
-      namespace,
-      body: {
-        scope: [scope],
-        payload: params,
-      },
-      onData: ({ value }) => {
-        if (value != null) {
-          resolve(value);
-          clearTimeout(rejectTimerId);
-        }
-      },
-      ...options,
-    });
+  const query = useQuery({
+    queryKey: ['walletCheckActivity', params, source],
+    queryFn: () => ZerionAPI.walletCheckActivity(params, { source }),
+    enabled: enabled && params.addresses.length > 0,
+    keepPreviousData,
+    staleTime: 20000,
   });
+  return {
+    ...query,
+    isLoading: query.isInitialLoading,
+    value: query.data ?? null,
+  };
 }


### PR DESCRIPTION
Part of [WLT-2383](https://linear.app/zerion/issue/WLT-2383) (incremental defi-sdk removal). Ticket: [WLT-2387](https://linear.app/zerion/issue/WLT-2387). **Stacked on #970** — merge that first.

## What

- New request module `wallet-check-activity.ts` posts to `wallet/check-activity/v1` and adapts ZPI's `{ address, activityStatus }[]` back to the socket's `Record<normalizeAddress(address), { address, active }>` **inside the module**, so all consumers (including `helpers.ts`'s normalized lookup) are untouched. No `Zerion-Wallet-Provider` header — the addresses aren't imported yet.
- `useAddressActivity` becomes a `useQuery` hook with `source` required and non-defaulted (WLT-2184); `keepStaleData` maps to `keepPreviousData`. Both onboarding consumers pass `useHttpClientSource()`.
- The imperative `getAddressActivity` is replaced by a `backgroundQueryClient.fetchQuery` wrapper in `getUserProperties.ts` with `source: 'mainnet'` written literally — the old singleton pinned it to mainnet accidentally; now it's declared. Also removes a background → src/ui import.

## QA

- Mnemonic import wallet-scan during onboarding: active addresses get pre-selected.
- `getUserProperties` analytics still reports funded stats per ecosystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)