### PR TITLE
WLT-2390 (PR 7/13): vendor the legacy defi-sdk types

### DIFF
--- a/src/defi-sdk.types.ts
+++ b/src/defi-sdk.types.ts
@@ -1,0 +1,293 @@
+/**
+ * Vendored copies of the `defi-sdk` data shapes that outlive the package.
+ *
+ * These are verbatim ports of the interfaces `defi-sdk` used to export, kept
+ * here so the extension's type dependency on the package is severed
+ * independently of its runtime dependency (the socket client). Nothing in this
+ * file is authored: if a shape looks wrong, it is wrong in the same way the
+ * backend response was.
+ *
+ * Deliberately NOT vendored:
+ * - `CachePolicy`, `Result` — defi-sdk request mechanics, not data shapes.
+ *   They disappear along with the socket domains rather than move here.
+ * - `AddressMembership` — goes away with `useAddressMembership.ts`.
+ *
+ * New code should prefer the `src/modules/zerion-api` response types.
+ */
+
+/* -------------------------------------------------------------------------- */
+/* Asset                                                                      */
+/* -------------------------------------------------------------------------- */
+
+interface Price {
+  value: number;
+  relative_change_24h: number;
+  changed_at: number;
+}
+
+export interface Asset {
+  id: string;
+  asset_code: string;
+  decimals: number;
+  icon_url: string | null;
+  name: string;
+  price: Price | null;
+  symbol: string;
+  type: string | null;
+  is_displayable: boolean;
+  is_verified: boolean;
+  addresses?: {
+    [key: string]: string;
+  };
+  implementations?: {
+    [key: string]: {
+      address: string | null;
+      decimals: number;
+    };
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* AddressPosition                                                            */
+/* -------------------------------------------------------------------------- */
+
+export type PositionType =
+  | 'asset'
+  | 'deposit'
+  | 'loan'
+  | 'reward'
+  | 'staked'
+  | 'locked';
+
+export interface AddressPositionDappInfo {
+  id: string;
+  name: string | null;
+  url: string | null;
+  icon_url: string | null;
+}
+
+export interface AddressPosition {
+  apy: string | null;
+  asset: Asset;
+  chain: string;
+  id: string;
+  included_in_chart: boolean;
+  name: string;
+  parent_id: string | null;
+  protocol: string | null;
+  quantity: string | null;
+  type: PositionType;
+  value: string | null;
+  is_displayable: boolean;
+  dapp: AddressPositionDappInfo | null;
+}
+
+/* -------------------------------------------------------------------------- */
+/* NFT                                                                        */
+/* -------------------------------------------------------------------------- */
+
+interface MediaContentValue {
+  image_preview_url?: string;
+  image_url?: string | null;
+  audio_url?: string | null;
+  video_url?: string | null;
+  type: 'video' | 'image' | 'audio';
+}
+
+interface NFTAttribute {
+  key: string;
+  value?: string;
+}
+
+interface NFTMetadata {
+  name: string;
+  description?: string;
+  tags: string[];
+  content?: MediaContentValue;
+  attributes: NFTAttribute[];
+}
+
+interface ConvertedPrices {
+  floor_price: number;
+  total_floor_price?: number;
+  currency: string;
+}
+
+interface NativePrices {
+  floor_price: number;
+  total_floor_price?: number;
+  buy_now_price?: number;
+  payment_token: {
+    symbol: string;
+  };
+}
+
+interface NFTPrice {
+  native?: NativePrices;
+  converted?: ConvertedPrices;
+}
+
+export interface NFTCollection {
+  id: number;
+  name?: string;
+  description?: string;
+  icon_url?: string;
+  payment_token_symbol?: string;
+  slug?: string;
+}
+
+export interface NFT {
+  contract_address: string;
+  contract_standard: 'ERC721' | 'ERC1155' | 'CRYPTOPUNKS';
+  token_id: string;
+  chain: string;
+  metadata: NFTMetadata;
+  collection: NFTCollection;
+  prices: NFTPrice;
+  relevant_urls?: {
+    name: string;
+    url: string;
+  }[];
+}
+
+export interface AddressNFT extends NFT {
+  changed_at?: number;
+  amount?: number;
+}
+
+/* -------------------------------------------------------------------------- */
+/* NFTAsset                                                                   */
+/* -------------------------------------------------------------------------- */
+
+interface NFTCollectionInfo {
+  description: string | null;
+  icon_url: string | null;
+  name: string;
+  slug: string;
+}
+
+interface NFTContent {
+  url: string | null;
+  meta: null | {
+    [key: string]: string;
+  };
+}
+
+export interface NFTAsset {
+  asset_code: string;
+  name: string;
+  symbol: string;
+  preview: NFTContent;
+  detail: NFTContent;
+  interface: string;
+  contract_address: string;
+  token_id: string;
+  type: 'nft';
+  price: null | {
+    value: number;
+  };
+  icon_url: string | null;
+  is_verified: boolean;
+  collection: NFTCollection | null;
+  collection_info: NFTCollectionInfo | null;
+  tags: string | null;
+  floor_price: number;
+  last_price: number;
+}
+
+/* -------------------------------------------------------------------------- */
+/* AddressAction                                                              */
+/* -------------------------------------------------------------------------- */
+
+type TransactionStatus = 'confirmed' | 'failed' | 'pending';
+
+type ActionType =
+  | 'send'
+  | 'receive'
+  | 'trade'
+  | 'approve'
+  | 'revoke'
+  | 'execute'
+  | 'deploy'
+  | 'cancel'
+  | 'deposit'
+  | 'withdraw'
+  | 'borrow'
+  | 'repay'
+  | 'stake'
+  | 'unstake'
+  | 'claim'
+  | 'mint'
+  | 'burn';
+
+export type ActionAsset =
+  | {
+      fungible: Asset | Record<string, never>;
+    }
+  | {
+      nft: NFTAsset | Record<string, never>;
+    };
+
+interface ActionTransfer {
+  asset: ActionAsset;
+  quantity: string;
+  price: number | null;
+  recipient?: string | null;
+  sender?: string | null;
+}
+
+interface ActionTransfers {
+  outgoing?: ActionTransfer[];
+  incoming?: ActionTransfer[];
+}
+
+interface ApprovalNFTCollection extends Omit<NFTCollection, 'id'> {
+  id: string;
+}
+
+export interface AddressAction {
+  id: string;
+  datetime: string;
+  address: string;
+  type: {
+    value: ActionType;
+    display_value: string;
+  };
+  transaction: {
+    chain: string;
+    hash: string;
+    status: TransactionStatus;
+    nonce: number;
+    sponsored: boolean;
+    fee: {
+      asset: ActionAsset;
+      quantity: string;
+      price: number | null;
+    } | null;
+    gasback?: number | null;
+  };
+  label: {
+    type: 'to' | 'from' | 'application' | 'contract';
+    value: string;
+    icon_url?: string;
+    display_value: {
+      wallet_address?: string;
+      contract_address?: string;
+      text?: string;
+    };
+  } | null;
+  content: {
+    transfers?: ActionTransfers;
+    single_asset?: {
+      asset: ActionAsset;
+      quantity: string;
+    };
+    collection?: ApprovalNFTCollection;
+  } | null;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Request params                                                             */
+/* -------------------------------------------------------------------------- */
+
+export type AddressParams = { address: string } | { addresses: string[] };

--- a/src/modules/defi-sdk/queries.ts
+++ b/src/modules/defi-sdk/queries.ts
@@ -1,4 +1,4 @@
-import type { AddressPosition, Asset } from 'defi-sdk';
+import type { AddressPosition, Asset } from 'src/defi-sdk.types';
 import { type Client, type client as clientType } from 'defi-sdk';
 import type { ResponseData as AssetsPricesReponseData } from 'defi-sdk/lib/domains/assetsPrices';
 import { backgroundCache } from 'src/modules/defi-sdk';

--- a/src/modules/ethereum/transactions/actionAsset.ts
+++ b/src/modules/ethereum/transactions/actionAsset.ts
@@ -1,4 +1,4 @@
-import type { ActionAsset, Asset, NFTAsset } from 'defi-sdk';
+import type { ActionAsset, Asset, NFTAsset } from 'src/defi-sdk.types';
 
 export function getFungibleAsset(asset?: ActionAsset) {
   if (

--- a/src/modules/ethereum/transactions/addressAction/addressActionMain.ts
+++ b/src/modules/ethereum/transactions/addressAction/addressActionMain.ts
@@ -8,7 +8,7 @@ import type {
   NFTPreview,
 } from 'src/modules/zerion-api/requests/wallet-get-actions';
 import { invariant } from 'src/shared/invariant';
-import type { Asset, NFT } from 'defi-sdk';
+import type { Asset, NFT } from 'src/defi-sdk.types';
 import type { NetworkConfig } from 'src/modules/networks/NetworkConfig';
 import type { Quote2 } from 'src/shared/types/Quote';
 import type { Fungible } from 'src/modules/zerion-api/types/Fungible';

--- a/src/modules/networks/Networks.ts
+++ b/src/modules/networks/Networks.ts
@@ -1,4 +1,4 @@
-import type { Asset } from 'defi-sdk';
+import type { Asset } from 'src/defi-sdk.types';
 import { isTruthy } from 'is-truthy-ts';
 import { capitalize } from 'capitalize-ts';
 import type { AddEthereumChainParameter } from 'src/modules/ethereum/types/AddEthereumChainParameter';

--- a/src/modules/networks/asset.ts
+++ b/src/modules/networks/asset.ts
@@ -1,4 +1,4 @@
-import type { Asset } from 'defi-sdk';
+import type { Asset } from 'src/defi-sdk.types';
 import { baseToCommon, commonToBase } from 'src/shared/units/convert';
 import type BigNumber from 'bignumber.js';
 import type { Chain } from './Chain';

--- a/src/modules/zerion-api/requests/wallet-get-positions.ts
+++ b/src/modules/zerion-api/requests/wallet-get-positions.ts
@@ -3,7 +3,7 @@ import type {
   Asset as DefiSdkAsset,
   AddressPositionDappInfo as DefiSdkAddressPositionDappInfo,
   PositionType,
-} from 'defi-sdk';
+} from 'src/defi-sdk.types';
 import type { Chain } from 'src/modules/networks/Chain';
 import type { ClientOptions } from '../shared';
 import { ZerionHttpClient } from '../shared';

--- a/src/ui/components/AllowanceForm/AllowanceForm.tsx
+++ b/src/ui/components/AllowanceForm/AllowanceForm.tsx
@@ -8,7 +8,7 @@ import { Toggle } from 'src/ui/ui-kit/Toggle';
 import { TokenIcon } from 'src/ui/ui-kit/TokenIcon';
 import UnknownIcon from 'jsx:src/ui/assets/actionTypes/unknown.svg';
 import { UnstyledInput } from 'src/ui/ui-kit/UnstyledInput';
-import type { Asset } from 'defi-sdk';
+import type { Asset } from 'src/defi-sdk.types';
 import BigNumber from 'bignumber.js';
 import { collectData } from 'src/ui/shared/form-data';
 import { Spacer } from 'src/ui/ui-kit/Spacer';

--- a/src/ui/components/AssetLink/AssetLink.tsx
+++ b/src/ui/components/AssetLink/AssetLink.tsx
@@ -1,4 +1,4 @@
-import type { Asset } from 'defi-sdk';
+import type { Asset } from 'src/defi-sdk.types';
 import React from 'react';
 import type { Fungible } from 'src/modules/zerion-api/types/Fungible';
 import { usePreferences } from 'src/ui/features/preferences';

--- a/src/ui/components/Positions/groupPositions.ts
+++ b/src/ui/components/Positions/groupPositions.ts
@@ -1,7 +1,7 @@
 /**
  * Taken and adapted from pulse-frontend/Root/App/Main/tabs/Overview/Positions/groupPositions.ts
  */
-import type { AddressPosition } from 'defi-sdk';
+import type { AddressPosition } from 'src/defi-sdk.types';
 import groupBy from 'lodash/groupBy';
 import type { Chain } from 'src/modules/networks/Chain';
 import {

--- a/src/ui/components/Positions/helpers.tsx
+++ b/src/ui/components/Positions/helpers.tsx
@@ -1,7 +1,7 @@
 /**
  * Taken and adapted from pulse-frontend/Root/App/Main/tabs/Overview/Positions/helpers.ts
  */
-import type { AddressPosition, PositionType } from 'defi-sdk';
+import type { AddressPosition, PositionType } from 'src/defi-sdk.types';
 import { baseToCommon } from 'src/shared/units/convert';
 import { getDecimals } from 'src/modules/networks/asset';
 import { createChain } from 'src/modules/networks/Chain';

--- a/src/ui/components/Positions/types.ts
+++ b/src/ui/components/Positions/types.ts
@@ -1,4 +1,4 @@
-import type { AddressPosition } from 'defi-sdk';
+import type { AddressPosition } from 'src/defi-sdk.types';
 
 export enum PositionsGroupType {
   platform = 'platform',

--- a/src/ui/pages/NonFungibleToken/getEntityUrl.ts
+++ b/src/ui/pages/NonFungibleToken/getEntityUrl.ts
@@ -1,4 +1,4 @@
-import type { AddressNFT } from 'defi-sdk';
+import type { AddressNFT } from 'src/defi-sdk.types';
 
 export function getNftEntityUrl(nft: AddressNFT) {
   return `/nft/${nft.chain}/${nft.contract_address}:${nft.token_id}`;

--- a/src/ui/pages/NonFungibleToken/useAddressNftPosition.ts
+++ b/src/ui/pages/NonFungibleToken/useAddressNftPosition.ts
@@ -1,5 +1,6 @@
 import { client, createDomainHook } from 'defi-sdk';
-import type { AddressNFT, AddressParams, Result } from 'defi-sdk';
+import type { Result } from 'defi-sdk';
+import type { AddressNFT, AddressParams } from 'src/defi-sdk.types';
 
 type Payload = AddressParams & {
   currency: string;

--- a/src/ui/pages/Overview/NonFungibleTokens/NonFungibleTokens.tsx
+++ b/src/ui/pages/Overview/NonFungibleTokens/NonFungibleTokens.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import type { AddressNFT } from 'defi-sdk';
+import type { AddressNFT } from 'src/defi-sdk.types';
 import { formatCurrencyToParts } from 'src/shared/units/formatCurrencyValue';
 import TickIcon from 'jsx:src/ui/assets/check.svg';
 import comingSoonImgSrc from 'url:src/ui/assets/coming-soon@2x.png';

--- a/src/ui/pages/Overview/Positions/DappLink.tsx
+++ b/src/ui/pages/Overview/Positions/DappLink.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import type { AddressPositionDappInfo } from 'defi-sdk';
+import type { AddressPositionDappInfo } from 'src/defi-sdk.types';
 import { HStack } from 'src/ui/ui-kit/HStack';
 import { UIText } from 'src/ui/ui-kit/UIText';
 import { prepareForHref } from 'src/ui/shared/prepareForHref';

--- a/src/ui/pages/Overview/Positions/Positions.tsx
+++ b/src/ui/pages/Overview/Positions/Positions.tsx
@@ -1,4 +1,7 @@
-import type { AddressPosition, AddressPositionDappInfo } from 'defi-sdk';
+import type {
+  AddressPosition,
+  AddressPositionDappInfo,
+} from 'src/defi-sdk.types';
 import React, { useCallback, useMemo, useState } from 'react';
 import { Tooltip, TooltipAnchor, TooltipProvider } from 'src/ui/ui-kit/Tooltip';
 import {

--- a/src/ui/pages/SendForm2/shared/buildSolanaTransfer.ts
+++ b/src/ui/pages/SendForm2/shared/buildSolanaTransfer.ts
@@ -12,7 +12,7 @@ import {
   getMint,
   createAssociatedTokenAccountInstruction,
 } from '@solana/spl-token';
-import type { AddressPosition } from 'defi-sdk';
+import type { AddressPosition } from 'src/defi-sdk.types';
 import type { EmptyAddressPosition } from '@zeriontech/transactions';
 import { Networks } from 'src/modules/networks/Networks';
 import type { NetworkConfig } from 'src/modules/networks/NetworkConfig';

--- a/src/ui/pages/SendForm2/shared/fungiblePositionToAddressPosition.ts
+++ b/src/ui/pages/SendForm2/shared/fungiblePositionToAddressPosition.ts
@@ -1,4 +1,4 @@
-import type { AddressPosition } from 'defi-sdk';
+import type { AddressPosition } from 'src/defi-sdk.types';
 import type { FungiblePosition } from 'src/modules/zerion-api/requests/wallet-get-simple-positions';
 import { commonToBase } from 'src/shared/units/convert';
 

--- a/src/ui/pages/SendForm2/shared/nftPositionToDefiSdkNft.ts
+++ b/src/ui/pages/SendForm2/shared/nftPositionToDefiSdkNft.ts
@@ -1,4 +1,4 @@
-import type { NFT } from 'defi-sdk';
+import type { NFT } from 'src/defi-sdk.types';
 import type { NftPosition } from 'src/modules/zerion-api/requests/wallet-get-nft-positions';
 
 /**

--- a/src/ui/pages/SendForm2/shared/prepareSendData.ts
+++ b/src/ui/pages/SendForm2/shared/prepareSendData.ts
@@ -1,6 +1,7 @@
 import type { EmptyAddressPosition } from '@zeriontech/transactions';
 import { createSendNativeOrContractTransaction } from '@zeriontech/transactions';
-import type { AddressPosition, Client } from 'defi-sdk';
+import type { Client } from 'defi-sdk';
+import type { AddressPosition } from 'src/defi-sdk.types';
 import {
   adjustedCheckEligibility,
   fetchAndAssignPaymaster,

--- a/src/ui/pages/SendTransaction/TransactionConfiguration/useTransactionFee.ts
+++ b/src/ui/pages/SendTransaction/TransactionConfiguration/useTransactionFee.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo } from 'react';
-import type { Asset } from 'defi-sdk';
+import type { Asset } from 'src/defi-sdk.types';
 import { isTruthy } from 'is-truthy-ts';
 import { useQuery } from '@tanstack/react-query';
 import BigNumber from 'bignumber.js';

--- a/src/ui/shared/requests/addressNfts/useAddressNfts.ts
+++ b/src/ui/shared/requests/addressNfts/useAddressNfts.ts
@@ -1,4 +1,5 @@
-import type { AddressNFT, AddressParams, Result } from 'defi-sdk';
+import type { Result } from 'defi-sdk';
+import type { AddressNFT, AddressParams } from 'src/defi-sdk.types';
 import { client, createPaginatedDomainHook } from 'defi-sdk';
 
 export function getNftId(nft: AddressNFT) {

--- a/src/ui/shared/requests/fetchAddressPositionFromRpcNode.ts
+++ b/src/ui/shared/requests/fetchAddressPositionFromRpcNode.ts
@@ -1,5 +1,5 @@
 import { Connection, PublicKey } from '@solana/web3.js';
-import type { AddressPosition } from 'defi-sdk';
+import type { AddressPosition } from 'src/defi-sdk.types';
 import type { NetworkConfig } from 'src/modules/networks/NetworkConfig';
 import { Networks } from 'src/modules/networks/Networks';
 import { isMatchForEcosystem } from 'src/shared/wallet/shared';

--- a/src/ui/shared/requests/shared/createAddressPosition.ts
+++ b/src/ui/shared/requests/shared/createAddressPosition.ts
@@ -1,5 +1,5 @@
 import { capitalize } from 'capitalize-ts';
-import type { AddressPosition } from 'defi-sdk';
+import type { AddressPosition } from 'src/defi-sdk.types';
 import type { NetworkConfig } from 'src/modules/networks/NetworkConfig';
 
 export function createAddressPosition({

--- a/src/ui/shared/requests/useAddressMembership.ts
+++ b/src/ui/shared/requests/useAddressMembership.ts
@@ -1,4 +1,4 @@
-import type { AddressParams } from 'defi-sdk';
+import type { AddressParams } from 'src/defi-sdk.types';
 import { createDomainHook } from 'defi-sdk';
 
 const namespace = 'address';

--- a/src/ui/shared/requests/useNativeBalance.ts
+++ b/src/ui/shared/requests/useNativeBalance.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { type AddressPosition } from 'defi-sdk';
+import type { AddressPosition } from 'src/defi-sdk.types';
 import type { Chain } from 'src/modules/networks/Chain';
 import { baseToCommon } from 'src/shared/units/convert';
 import BigNumber from 'bignumber.js';

--- a/src/ui/transactions/filterAddressTransactions.ts
+++ b/src/ui/transactions/filterAddressTransactions.ts
@@ -1,4 +1,4 @@
-import type { AddressParams } from 'defi-sdk';
+import type { AddressParams } from 'src/defi-sdk.types';
 import type { TransactionObject } from 'src/modules/ethereum/transactions/types';
 import { normalizeAddress } from 'src/shared/normalizeAddress';
 

--- a/src/ui/transactions/useLocalAddressTransactions.ts
+++ b/src/ui/transactions/useLocalAddressTransactions.ts
@@ -1,5 +1,5 @@
 import { useStore } from '@store-unit/react';
-import type { AddressParams } from 'defi-sdk';
+import type { AddressParams } from 'src/defi-sdk.types';
 import { useMemo } from 'react';
 import { filterAddressTransactions } from './filterAddressTransactions';
 import { localTransactionsStore } from './transactions-store';


### PR DESCRIPTION
Part of [WLT-2383](https://linear.app/zerion/issue/WLT-2383/extension-remove-defi-sdk-incrementally-one-request-per-pr) · Ticket: [WLT-2390](https://linear.app/zerion/issue/WLT-2390/pr-7-vendor-the-legacy-defi-sdk-types)

**Stacked on #974 — merge that first.** (#968 ← #969 ← #970 ← #972 ← #973 ← #974 ← this)

## What

Type-only PR, zero runtime change.

- Creates `src/defi-sdk.types.ts` with verbatim ports of the eleven defi-sdk data shapes that outlive the package: `Asset`, `AddressPosition`, `AddressNFT`, `NFT`, `NFTCollection`, `AddressAction`, `ActionAsset`, `NFTAsset`, `AddressPositionDappInfo`, `AddressParams`, `PositionType`.
- Codemods the `import type` sites over to it, splitting statements that pulled types and runtime from `defi-sdk` together so the runtime import stays put for the later ports.
- `CachePolicy`/`Result` are request mechanics, not data shapes — deliberately not vendored. `AddressMembership` goes with `useAddressMembership.ts` in PR 8.

Adaptation vs the seed commit: two of its 30 sites no longer exist on this stack (`getLatestNonceKnownByBackend.ts` became the ZPI-based `backendKnowsTransaction.ts` in PR 2; `useNftsTotalValue.ts` was deleted in PR 3), and a tree-wide post-pass found no new type-import sites from main drift. Files importing `defi-sdk`: 54 → 27.

## QA

None beyond green tsc / lint / jest — no runtime change. (tsc exit 0; jest 37/38 suites, 365/366 tests — only the known optimism fee-drift failure.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)